### PR TITLE
Separate ldns parsing from clap parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
-version = "1.1.35"
+version = "1.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
 dependencies = [
  "shlex",
 ]
@@ -139,6 +139,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "domain",
+ "lexopt",
  "octseq",
  "ring",
 ]
@@ -179,10 +180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "libc"
-version = "0.2.161"
+name = "lexopt"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
+
+[[package]]
+name = "libc"
+version = "0.2.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "num-conv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 domain = "0.10.1"
+lexopt = "0.3.0"
 
 # for implementation of nsec3 hash until domain has it stabilized
 octseq = { version = "0.5.1", features = ["std"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,3 +13,9 @@ impl Args {
         self.command.execute()
     }
 }
+
+impl From<Command> for Args {
+    fn from(value: Command) -> Self {
+        Args { command: value }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,13 @@
 pub mod help;
 pub mod nsec3hash;
 
+use std::ffi::OsStr;
+use std::str::FromStr;
+
+use nsec3hash::Nsec3Hash;
+
+use crate::Args;
+
 use super::error::Error;
 
 #[derive(Clone, Debug, clap::Subcommand)]
@@ -21,5 +28,57 @@ impl Command {
             Self::Nsec3Hash(nsec3hash) => nsec3hash.execute(),
             Self::Help(help) => help.execute(),
         }
+    }
+}
+
+/// A command that can be invoked in an LDNS compatibility mode
+///
+/// These commands do their own argument parsing, because clap cannot always
+/// (easily) parse arguments in the same way that the ldns tools do.
+///
+/// The `LdnsCommand::parse_ldns` function should parse arguments obtained
+/// with [`std::env::args`] or [`std::env::args_os`] and return an error in
+/// case of invalid arguments. The help string provided as
+/// [`LdnsCommand::HELP`] is automatically appended to returned errors.
+pub trait LdnsCommand: Into<Command> {
+    const HELP: &'static str;
+
+    fn parse_ldns() -> Result<Self, Error>;
+
+    fn parse_ldns_args() -> Result<Args, Error> {
+        match Self::parse_ldns() {
+            Ok(c) => Ok(Args::from(c.into())),
+            Err(e) => Err(format!("{e}\n\n{}", Self::HELP).into()),
+        }
+    }
+
+    /// Utility function to parse an [`OsStr`] with a custom function
+    fn parse_os_with<T, E>(
+        opt: &str,
+        val: &OsStr,
+        f: impl Fn(&str) -> Result<T, E>,
+    ) -> Result<T, Error>
+    where
+        E: std::fmt::Display,
+    {
+        let Some(s) = val.to_str() else {
+            return Err(format!("Invalid value for {opt}: {val:?} is not valid unicode",).into());
+        };
+
+        f(s).map_err(|e| format!("Invalid value {val:?} for {opt}: {e}").into())
+    }
+
+    /// Utility function to parse an [`OsStr`] into a value via [`FromStr`]
+    fn parse_os<T: FromStr>(opt: &str, val: &OsStr) -> Result<T, Error>
+    where
+        T::Err: std::fmt::Display,
+    {
+        Self::parse_os_with(opt, val, T::from_str)
+    }
+}
+
+impl From<Nsec3Hash> for Command {
+    fn from(val: Nsec3Hash) -> Self {
+        Command::Nsec3Hash(val)
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -51,34 +51,30 @@ pub trait LdnsCommand: Into<Command> {
             Err(e) => Err(format!("Error: {e}\n\n{}", Self::HELP).into()),
         }
     }
-
-    /// Utility function to parse an [`OsStr`] with a custom function
-    fn parse_os_with<T, E>(
-        opt: &str,
-        val: &OsStr,
-        f: impl Fn(&str) -> Result<T, E>,
-    ) -> Result<T, Error>
-    where
-        E: std::fmt::Display,
-    {
-        let Some(s) = val.to_str() else {
-            return Err(format!("Invalid value for {opt}: {val:?} is not valid unicode",).into());
-        };
-
-        f(s).map_err(|e| format!("Invalid value {val:?} for {opt}: {e}").into())
-    }
-
-    /// Utility function to parse an [`OsStr`] into a value via [`FromStr`]
-    fn parse_os<T: FromStr>(opt: &str, val: &OsStr) -> Result<T, Error>
-    where
-        T::Err: std::fmt::Display,
-    {
-        Self::parse_os_with(opt, val, T::from_str)
-    }
 }
 
 impl From<Nsec3Hash> for Command {
     fn from(val: Nsec3Hash) -> Self {
         Command::Nsec3Hash(val)
     }
+}
+
+/// Utility function to parse an [`OsStr`] with a custom function
+fn parse_os_with<T, E>(opt: &str, val: &OsStr, f: impl Fn(&str) -> Result<T, E>) -> Result<T, Error>
+where
+    E: std::fmt::Display,
+{
+    let Some(s) = val.to_str() else {
+        return Err(format!("Invalid value for {opt}: {val:?} is not valid unicode",).into());
+    };
+
+    f(s).map_err(|e| format!("Invalid value {val:?} for {opt}: {e}").into())
+}
+
+/// Utility function to parse an [`OsStr`] into a value via [`FromStr`]
+fn parse_os<T: FromStr>(opt: &str, val: &OsStr) -> Result<T, Error>
+where
+    T::Err: std::fmt::Display,
+{
+    parse_os_with(opt, val, T::from_str)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -48,7 +48,7 @@ pub trait LdnsCommand: Into<Command> {
     fn parse_ldns_args() -> Result<Args, Error> {
         match Self::parse_ldns() {
             Ok(c) => Ok(Args::from(c.into())),
-            Err(e) => Err(format!("{e}\n\n{}", Self::HELP).into()),
+            Err(e) => Err(format!("Error: {e}\n\n{}", Self::HELP).into()),
         }
     }
 

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 use super::LdnsCommand;
 
 #[derive(Clone, Debug, clap::Args)]
-#[command(args_override_self = true)]
 pub struct Nsec3Hash {
     /// The hashing algorithm to use
     #[arg(

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -10,7 +10,7 @@ use octseq::OctetsBuilder;
 use ring::digest;
 use std::str::FromStr;
 
-use super::LdnsCommand;
+use super::{parse_os, parse_os_with, LdnsCommand};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Nsec3Hash {
@@ -67,16 +67,15 @@ impl LdnsCommand for Nsec3Hash {
             match arg {
                 Arg::Short('a') => {
                     let val = parser.value()?;
-                    algorithm =
-                        Self::parse_os_with("algorithm (-a)", &val, Nsec3Hash::parse_nsec_alg)?;
+                    algorithm = parse_os_with("algorithm (-a)", &val, Nsec3Hash::parse_nsec_alg)?;
                 }
                 Arg::Short('s') => {
                     let val = parser.value()?;
-                    salt = Self::parse_os("salt (-s)", &val)?;
+                    salt = parse_os("salt (-s)", &val)?;
                 }
                 Arg::Short('t') => {
                     let val = parser.value()?;
-                    iterations = Self::parse_os("iterations (-t)", &val)?;
+                    iterations = parse_os("iterations (-t)", &val)?;
                 }
                 Arg::Value(val) => {
                     // Strange ldns compatibility case: only the first
@@ -84,7 +83,7 @@ impl LdnsCommand for Nsec3Hash {
                     if name.is_some() {
                         continue;
                     }
-                    name = Some(Self::parse_os("domain name", &val)?);
+                    name = Some(parse_os("domain name", &val)?);
                 }
                 Arg::Short(x) => return Err(format!("Invalid short option: -{x}").into()),
                 Arg::Long(x) => {

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -71,13 +71,13 @@ impl LdnsCommand for Nsec3Hash {
                     algorithm =
                         Self::parse_os_with("algorithm (-a)", &val, Nsec3Hash::parse_nsec_alg)?;
                 }
-                Arg::Short('t') => {
-                    let val = parser.value()?;
-                    iterations = Self::parse_os("iterations (-t)", &val)?;
-                }
                 Arg::Short('s') => {
                     let val = parser.value()?;
                     salt = Self::parse_os("salt (-s)", &val)?;
+                }
+                Arg::Short('t') => {
+                    let val = parser.value()?;
+                    iterations = Self::parse_os("iterations (-t)", &val)?;
                 }
                 Arg::Value(val) => {
                     // Strange ldns compatibility case: only the first

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,12 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<lexopt::Error> for Error {
+    fn from(value: lexopt::Error) -> Self {
+        value.to_string().into()
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.message, f)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,9 @@ fn main() {
 }
 
 fn try_ldns_compatibility() -> Option<dnst::Args> {
-    let binary_path = std::env::args_os().next().unwrap();
+    let binary_path = std::env::args_os().next()?;
 
-    let binary_name = Path::new(&binary_path)
-        .file_name()
-        .unwrap_or_default()
-        .to_str()
-        .unwrap_or_default();
+    let binary_name = Path::new(&binary_path).file_name()?.to_str()?;
 
     let res = match binary_name {
         "ldns-nsec3-hash" => Nsec3Hash::parse_ldns_args(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use dnst::commands::{nsec3hash::Nsec3Hash, LdnsCommand};
 fn main() {
     // If none of the ldns-* tools matched, then we continue with clap
     // argument parsing.
-    let args = try_ldns_compatibility().unwrap_or_else(parse_clap);
+    let args = try_ldns_compatibility().unwrap_or_else(dnst::Args::parse);
 
     if let Err(err) = args.execute() {
         eprintln!("{}", err);
@@ -28,19 +28,6 @@ fn try_ldns_compatibility() -> Option<dnst::Args> {
         Err(e) => {
             eprintln!("{e}");
             std::process::exit(1)
-        }
-    }
-}
-
-fn parse_clap() -> dnst::Args {
-    let res = dnst::Args::try_parse();
-    match res {
-        Ok(args) => args,
-        Err(e) => {
-            // Clap normally has an exit code of 2, but we want an
-            // exit code of 1.
-            e.print().unwrap();
-            std::process::exit(1);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,50 @@
+use std::path::Path;
+
 use clap::Parser;
+use dnst::commands::{nsec3hash::Nsec3Hash, LdnsCommand};
 
 fn main() {
-    if let Err(err) = dnst::Args::parse().execute() {
+    // If none of the ldns-* tools matched, then we continue with clap
+    // argument parsing.
+    let args = try_ldns_compatibility().unwrap_or_else(parse_clap);
+
+    if let Err(err) = args.execute() {
         eprintln!("{}", err);
+    }
+}
+
+fn try_ldns_compatibility() -> Option<dnst::Args> {
+    let binary_path = std::env::args_os().next().unwrap();
+
+    let binary_name = Path::new(&binary_path)
+        .file_name()
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default();
+
+    let res = match binary_name {
+        "ldns-nsec3-hash" => Nsec3Hash::parse_ldns_args(),
+        _ => return None,
+    };
+
+    match res {
+        Ok(args) => Some(args),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1)
+        }
+    }
+}
+
+fn parse_clap() -> dnst::Args {
+    let res = dnst::Args::try_parse();
+    match res {
+        Ok(args) => args,
+        Err(e) => {
+            // Clap normally has an exit code of 2, but we want an
+            // exit code of 1.
+            e.print().unwrap();
+            std::process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a separate code path for parsing arguments in a ldns-compatible way. The ldns tools cannot (in general) be parsed with clap, so they need full flexibility over how they parse their arguments. This parsing is only used when the binary is executed with the name of an ldns tool (either via renaming or a symlink). This also allows us to provide different defaults for the ldns and dnst tools.