### PR TITLE
Add `ldns` binary for easier testing of ldns tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "dnst"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "ldns"
+path = "src/bin/ldns.rs"
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 domain = "0.10.1"

--- a/src/bin/ldns.rs
+++ b/src/bin/ldns.rs
@@ -1,0 +1,17 @@
+use std::process::ExitCode;
+
+use dnst::try_ldns_compatibility;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args_os();
+    args.next().unwrap();
+    let args = try_ldns_compatibility(args).expect("ldns commmand is not recognized");
+
+    match args.execute() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            err.pretty_print();
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,7 +3,7 @@
 pub mod help;
 pub mod nsec3hash;
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::str::FromStr;
 
 use nsec3hash::Nsec3Hash;
@@ -36,17 +36,16 @@ impl Command {
 /// These commands do their own argument parsing, because clap cannot always
 /// (easily) parse arguments in the same way that the ldns tools do.
 ///
-/// The `LdnsCommand::parse_ldns` function should parse arguments obtained
-/// with [`std::env::args`] or [`std::env::args_os`] and return an error in
-/// case of invalid arguments. The help string provided as
-/// [`LdnsCommand::HELP`] is automatically appended to returned errors.
+/// The [`LdnsCommand::parse_ldns`] function should parse arguments and
+/// return an error in case of a parsing failure. The help string provided
+/// as [`LdnsCommand::HELP`] is automatically appended to returned errors.
 pub trait LdnsCommand: Into<Command> {
     const HELP: &'static str;
 
-    fn parse_ldns() -> Result<Self, Error>;
+    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Self, Error>;
 
-    fn parse_ldns_args() -> Result<Args, Error> {
-        match Self::parse_ldns() {
+    fn parse_ldns_args<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
+        match Self::parse_ldns(args) {
             Ok(c) => Ok(Args::from(c.into())),
             Err(e) => Err(format!("Error: {e}\n\n{}", Self::HELP).into()),
         }

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -8,6 +8,7 @@ use lexopt::Arg;
 // use domain::validator::nsec::nsec3_hash;
 use octseq::OctetsBuilder;
 use ring::digest;
+use std::ffi::OsString;
 use std::str::FromStr;
 
 use super::{parse_os, parse_os_with, LdnsCommand};
@@ -55,13 +56,13 @@ ldns-nsec3-hash [OPTIONS] <domain name>
 impl LdnsCommand for Nsec3Hash {
     const HELP: &'static str = LDNS_HELP;
 
-    fn parse_ldns() -> Result<Self, Error> {
+    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Self, Error> {
         let mut algorithm = Nsec3HashAlg::SHA1;
         let mut iterations = 1;
         let mut salt = Nsec3Salt::empty();
         let mut name = None;
 
-        let mut parser = lexopt::Parser::from_env();
+        let mut parser = lexopt::Parser::from_args(args);
 
         while let Some(arg) = parser.next()? {
             match arg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,29 @@
+use std::{ffi::OsString, path::Path};
+
+use commands::{nsec3hash::Nsec3Hash, LdnsCommand};
+
 pub use self::args::Args;
 
 pub mod args;
 pub mod commands;
 pub mod error;
+
+pub fn try_ldns_compatibility<I: IntoIterator<Item = OsString>>(args: I) -> Option<Args> {
+    let mut args_iter = args.into_iter();
+    let binary_path = args_iter.next()?;
+
+    let binary_name = Path::new(&binary_path).file_name()?.to_str()?;
+
+    let res = match binary_name {
+        "ldns-nsec3-hash" => Nsec3Hash::parse_ldns_args(args_iter),
+        _ => return None,
+    };
+
+    match res {
+        Ok(args) => Some(args),
+        Err(err) => {
+            err.pretty_print();
+            std::process::exit(1)
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,18 @@
-use std::path::Path;
 use std::process::ExitCode;
 
 use clap::Parser;
-use dnst::commands::{nsec3hash::Nsec3Hash, LdnsCommand};
 
 fn main() -> ExitCode {
     // If none of the ldns-* tools matched, then we continue with clap
     // argument parsing.
-    let args = try_ldns_compatibility().unwrap_or_else(dnst::Args::parse);
+    let env_args = std::env::args_os();
+    let args = dnst::try_ldns_compatibility(env_args).unwrap_or_else(dnst::Args::parse);
 
     match args.execute() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             err.pretty_print();
             ExitCode::FAILURE
-        }
-    }
-}
-
-fn try_ldns_compatibility() -> Option<dnst::Args> {
-    let binary_path = std::env::args_os().next()?;
-
-    let binary_name = Path::new(&binary_path).file_name()?.to_str()?;
-
-    let res = match binary_name {
-        "ldns-nsec3-hash" => Nsec3Hash::parse_ldns_args(),
-        _ => return None,
-    };
-
-    match res {
-        Ok(args) => Some(args),
-        Err(err) => {
-            err.pretty_print();
-            std::process::exit(1)
         }
     }
 }


### PR DESCRIPTION
Usage:
```
cargo run --bin ldns -- ldns-nsec3-hash
```
To make it easier to run these commands without making symlinks (and also being able to invoke it with `cargo run` and not `cargo build && ./ldns-nsec3-hash` and also making it possible to run it both with and without `--release`)

Side effect: the `try_ldns_compatibility` function now takes arguments so we can unit test it.