### PR TITLE
fix not having a default-run target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dnst"
 version = "0.1.0"
 edition = "2021"
+default-run = "dnst"
 
 [[bin]]
 name = "ldns"


### PR DESCRIPTION
Makes `cargo run` without `--bin dnst` work again.