### PR TITLE
Add manual pages

### DIFF
--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -189,8 +189,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('man/dnst', 'dnst', 'DNS Management Tools', author, 1),
-    ('man/dnst-nsec3-hash', 'dnst-nsec3-hash', 'DNS Management Tools', author,
-     1),
+    ('man/dnst-nsec3-hash', 'dnst-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
+    ('man/ldns-nsec3-hash', 'ldns-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
 ]
 
 

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -189,10 +189,18 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('man/dnst', 'dnst', 'DNS Management Tools', author, 1),
-    ('man/dnst-nsec3-hash', 'dnst-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
-    ('man/ldns-nsec3-hash', 'ldns-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
     ('man/dnst-key2ds', 'dnst-key2ds', 'Generate DS RRs from the DNSKEYs in a keyfile', author, 1),
     ('man/ldns-key2ds', 'ldns-key2ds', 'Generate DS RRs from the DNSKEYs in a keyfile', author, 1),
+    ('man/dnst-keygen', 'dnst-keygen', 'Generate a new key pair for a domain name', author, 1),
+    ('man/ldns-keygen', 'ldns-keygen', 'Generate a new key pair for a domain name', author, 1),
+    ('man/dnst-notify', 'dnst-notify', 'Send a NOTIFY message to a list of name servers', author, 1),
+    ('man/ldns-notify', 'ldns-notify', 'Send a NOTIFY message to a list of name servers', author, 1),
+    ('man/dnst-nsec3-hash', 'dnst-nsec3-hash', 'Print out the NSEC3 hash of a domain name', author, 1),
+    ('man/ldns-nsec3-hash', 'ldns-nsec3-hash', 'Print out the NSEC3 hash of a domain name', author, 1),
+    ('man/dnst-signzone', 'dnst-signzone', 'Sign the zone with the given key(s)', author, 1),
+    ('man/ldns-signzone', 'ldns-signzone', 'Sign the zone with the given key(s)', author, 1),
+    ('man/dnst-update', 'dnst-update', 'Send a dynamic update packet to update an IP (or delete all existing IPs) for a domain name', author, 1),
+    ('man/ldns-update', 'ldns-update', 'Send a dynamic update packet to update an IP (or delete all existing IPs) for a domain name', author, 1),
 ]
 
 

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -191,6 +191,8 @@ man_pages = [
     ('man/dnst', 'dnst', 'DNS Management Tools', author, 1),
     ('man/dnst-nsec3-hash', 'dnst-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
     ('man/ldns-nsec3-hash', 'ldns-nsec3-hash', 'print out the NSEC3 hash for a domain name', author, 1),
+    ('man/dnst-key2ds', 'dnst-key2ds', 'Generate DS RRs from the DNSKEYs in a keyfile', author, 1),
+    ('man/ldns-key2ds', 'ldns-key2ds', 'Generate DS RRs from the DNSKEYs in a keyfile', author, 1),
 ]
 
 

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -100,7 +100,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -1,7 +1,12 @@
 dnst |version|
 ==============
 
-The manual goes here ...
+**dnst** is a DNS administration toolbox. It offers DNS and DNSSEC related
+functions like key generation, zone signing, printing NSEC3 hashed domain
+names, and sending UPDATE or NOTIFY messages to your name servers. More is
+coming soon.
+
+It depends on OpenSSL for its cryptography related functions.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -16,6 +16,13 @@ The manual goes here ...
    man/dnst-nsec3-hash
    man/dnst-signzone
    man/dnst-update
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: LDNS Tools reference
+   :name: toc-reference-ldns
+
    man/ldns-key2ds
    man/ldns-keygen
    man/ldns-notify

--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -10,5 +10,15 @@ The manual goes here ...
    :name: toc-reference
    
    man/dnst
+   man/dnst-key2ds
+   man/dnst-keygen
+   man/dnst-notify
    man/dnst-nsec3-hash
-
+   man/dnst-signzone
+   man/dnst-update
+   man/ldns-key2ds
+   man/ldns-keygen
+   man/ldns-notify
+   man/ldns-nsec3-hash
+   man/ldns-signzone
+   man/ldns-update

--- a/doc/manual/source/man/dnst-key2ds.rst
+++ b/doc/manual/source/man/dnst-key2ds.rst
@@ -1,0 +1,42 @@
+dnst-key2ds
+===============
+
+Synopsis
+--------
+
+:program:`dnst key2ds` [``OPTIONS``] ``<KEYFILE>``
+
+Description
+-----------
+
+**dnst key2ds** generates a DS RR for each DNSKEY in ``<KEYFILE>``.
+
+The following file will be created for each key: ``K<name>+<alg>+<id>.ds``. The
+base name ``K<name>+<alg>+<id>`` will be printed to stdout.
+
+
+Options
+-------
+
+.. option:: -a <NUMBER OR MNEMONIC>, --algorithm <NUMBER OR MNEMONIC>
+
+      Use the given algorithm for the digest. Defaults to the digest algorithm
+      used for the DNSKEY, and if it can't be determined SHA-1.
+
+.. might change to --ignore-sep when implemented
+.. option:: -f
+
+      Ignore the SEP flag and make DS records for any key.
+
+.. option:: -n
+
+      Write the generated DS records to stdout instead of a file.
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).
+
+.. option:: -V, --version
+
+      Print the version.

--- a/doc/manual/source/man/dnst-key2ds.rst
+++ b/doc/manual/source/man/dnst-key2ds.rst
@@ -23,8 +23,11 @@ Options
       Use the given algorithm for the digest. Defaults to the digest algorithm
       used for the DNSKEY, and if it can't be determined SHA-1.
 
-.. might change to --ignore-sep when implemented
-.. option:: -f
+.. option:: -f, --force
+
+      Overwrite existing ``.ds`` files.
+
+.. option:: --ignore-sep
 
       Ignore the SEP flag and make DS records for any key.
 

--- a/doc/manual/source/man/dnst-key2ds.rst
+++ b/doc/manual/source/man/dnst-key2ds.rst
@@ -1,10 +1,10 @@
-dnst-key2ds
+dnst key2ds
 ===============
 
 Synopsis
 --------
 
-:program:`dnst key2ds` [``OPTIONS``] ``<KEYFILE>``
+:program:`dnst key2ds` ``[OPTIONS]`` ``<KEYFILE>``
 
 Description
 -----------

--- a/doc/manual/source/man/dnst-keygen.rst
+++ b/doc/manual/source/man/dnst-keygen.rst
@@ -1,10 +1,10 @@
-dnst-keygen
+dnst keygen
 ===============
 
 Synopsis
 --------
 
-:program:`dnst keygen` [``OPTIONS``] ``-a <ALGORITHM>`` ``<DOMAIN NAME>``
+:program:`dnst keygen` ``[OPTIONS]`` ``-a <ALGORITHM>`` ``<DOMAIN NAME>``
 
 Description
 -----------

--- a/doc/manual/source/man/dnst-keygen.rst
+++ b/doc/manual/source/man/dnst-keygen.rst
@@ -1,0 +1,78 @@
+dnst-keygen
+===============
+
+Synopsis
+--------
+
+:program:`dnst keygen` [``OPTIONS``] ``-a <ALGORITHM>`` ``<DOMAIN NAME>``
+
+Description
+-----------
+
+**dnst keygen** generates a new key pair for a given domain name.
+
+The following files will be created:
+
+- ``K<name>+<alg>+<tag>.key``: The public key file containing a DNSKEY RR in
+  zone file format.
+
+- ``K<name>+<alg>+<tag>.private``: The private key file containing the private
+  key data fields in BIND's *Private-key-format*.
+
+- ``K<name>+<alg>+<tag>.ds``: The public key digest file containing the DS RR
+  in zone file format. It is only created for key signing keys.
+
+| ``<name>`` is the fully-qualified owner name for the key (with a trailing dot).
+| ``<alg>`` is the algorithm number of the key, zero-padded to 3 digits.
+| ``<tag>`` is the 16-bit tag of the key, zero-padded to 5 digits.
+
+Upon completion, ``K<name>+<alg>+<tag>`` will be printed.
+
+Options
+-------
+
+.. option:: -a <MNEMONIC>
+
+      Use the given signing algorithm.
+
+      Possible values:
+
+      .. table::
+            :widths: auto
+
+            ==================== ========================
+            **Mnemonic**         **Description**
+            ==================== ========================
+            ``list``             List all algorithms
+            ``RSASHA256``        RSA with SHA-256
+            ``ECDSAP256SHA256``  ECDSA P-256 with SHA-256
+            ``ECDSAP384SHA384``  ECDSA P-384 with SHA-384
+            ``ED25519``          ED25519
+            ``ED448``            ED448
+            ==================== ========================
+
+
+.. option:: -k
+
+      Generate a key signing key (KSK) instead of a zone signing key (ZSK).
+
+.. option:: -b <BITS>
+
+      The length of the key (for RSA keys only). Defaults to 2048.
+
+.. option:: -r <DEVICE>
+
+      The randomness source to use for generation. Defaults to ``/dev/urandom``.
+
+.. option:: -s
+
+      Create symlinks ``.key`` and ``.private`` to the generated keys.
+
+.. option:: -f
+
+      Overwrite existing symlinks (for use with ``-s``).
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).

--- a/doc/manual/source/man/dnst-keygen.rst
+++ b/doc/manual/source/man/dnst-keygen.rst
@@ -35,22 +35,9 @@ Options
 
       Use the given signing algorithm.
 
-      Possible values:
-
-      .. table::
-            :widths: auto
-
-            ==================== ========================
-            **Mnemonic**         **Description**
-            ==================== ========================
-            ``list``             List all algorithms
-            ``RSASHA256``        RSA with SHA-256
-            ``ECDSAP256SHA256``  ECDSA P-256 with SHA-256
-            ``ECDSAP384SHA384``  ECDSA P-384 with SHA-384
-            ``ED25519``          ED25519
-            ``ED448``            ED448
-            ==================== ========================
-
+      Possible values are ``RSASHA256``, ``ECDSAP256SHA256``,
+      ``ECDSAP384SHA384``, ``ED25519``, ``ED448``; or ``list`` to list all
+      available algorithms.
 
 .. option:: -k
 

--- a/doc/manual/source/man/dnst-keygen.rst
+++ b/doc/manual/source/man/dnst-keygen.rst
@@ -31,13 +31,22 @@ Upon completion, ``K<name>+<alg>+<tag>`` will be printed.
 Options
 -------
 
-.. option:: -a <MNEMONIC>
+.. option:: -a <NUMBER OR MNEMONIC>
 
       Use the given signing algorithm.
 
-      Possible values are ``RSASHA256``, ``ECDSAP256SHA256``,
-      ``ECDSAP384SHA384``, ``ED25519``, ``ED448``; or ``list`` to list all
-      available algorithms.
+      Possible values are:
+
+      =================== ========== =========================
+      **Mnemonic**        **Number** **Description**
+      =================== ========== =========================
+      ``list``                       List available algorithms
+      ``RSASHA256``        8         RSA with SHA-256
+      ``ECDSAP256SHA256`` 13         ECDSA P-256 with SHA-256
+      ``ECDSAP384SHA384`` 14         ECDSA P-384 with SHA-384
+      ``ED25519``         15         ED25519
+      ``ED448``           16         ED448
+      =================== ========== =========================
 
 .. option:: -k
 

--- a/doc/manual/source/man/dnst-notify.rst
+++ b/doc/manual/source/man/dnst-notify.rst
@@ -1,10 +1,10 @@
-dnst-notify
+dnst notify
 ===============
 
 Synopsis
 --------
 
-:program:`dnst notify` [``OPTIONS``] ``-z <ZONE>`` ``<SERVERS>...``
+:program:`dnst notify` ``[OPTIONS]`` ``-z <ZONE>`` ``<SERVERS>...``
 
 Description
 -----------
@@ -27,7 +27,7 @@ Options
 
       SOA version number to include in the NOTIFY message.
 
-.. option:: -y, --tsig <name:key[:algo]>
+.. option:: -y, --tsig <NAME:KEY[:ALGO]>
 
       A base64 TSIG key and optional algorithm to use for the NOTIFY message.
       The algorithm defaults to **hmac-sha512**.

--- a/doc/manual/source/man/dnst-notify.rst
+++ b/doc/manual/source/man/dnst-notify.rst
@@ -1,0 +1,50 @@
+dnst-notify
+===============
+
+Synopsis
+--------
+
+:program:`dnst notify` [``OPTIONS``] ``-z <ZONE>`` ``<SERVERS>...``
+
+Description
+-----------
+
+**dnst notify** sends a NOTIFY message to the specified name servers. A name
+server can be specified as a domain name or IP address.
+
+This tells them that an updated zone is available at the primaries. It can
+perform TSIG signatures, and it can add a SOA serial number of the updated
+zone. If a server already has that serial number it will disregard the message.
+
+Options
+-------
+
+.. option:: -z <ZONE>
+
+      The zone to send the NOTIFY for.
+
+.. option:: -s <SOA VERSION>
+
+      SOA version number to include in the NOTIFY message.
+
+.. option:: -y, --tsig <name:key[:algo]>
+
+      A base64 TSIG key and optional algorithm to use for the NOTIFY message.
+      The algorithm defaults to **hmac-sha512**.
+
+.. option:: -p, --port <PORT>
+
+      Destination port to send the UDP packet to. Defaults to 53.
+
+.. option:: -d, --debug
+
+      Print debug information.
+
+.. option:: -r, --retries <RETRIES>
+
+      Max number of retries. Defaults to 15.
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -21,12 +21,13 @@ Options
 
 .. option:: -i <NUMBER>, -t <NUMBER>, --iterations <NUMBER>
 
-      Use the given number of additional iterations for the hash calculation.
+      Use the given number of additional iterations for the hash
+      calculation. Defaults to 0.
 
 .. option:: -s <HEX STRING>, --salt <HEX STRING>
 
       Use the given salt for the hash calculation. The salt value should be
-      in hexadecimal format.
+      in hexadecimal format. Defaults to an empty salt.
 
 .. option:: -h, --help
 

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -4,7 +4,7 @@ dnst-nsec3-hash
 Synopsis
 --------
 
-:program:`dnst nsec3-hash` [``OPTIONS``] :samp:`<DOMAIN NAME>`
+:program:`dnst nsec3-hash` [``OPTIONS``] ``<DOMAIN NAME>``
 
 Description
 -----------
@@ -28,3 +28,11 @@ Options
       Use the given salt for the hash calculation. The salt value should be
       in hexadecimal format.
 
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).
+
+.. option:: -V, --version
+
+      Print the version.

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -4,27 +4,27 @@ dnst-nsec3-hash
 Synopsis
 --------
 
-:program:`dnst nsec3-hash` [``options``] :samp:`domain-name`
+:program:`dnst nsec3-hash` [``OPTIONS``] :samp:`<DOMAIN NAME>`
 
 Description
 -----------
 
-**dnst nsec3-hash** prints the NSEC3 hash for the given domain name.
+**dnst nsec3-hash** prints the NSEC3 hash of a given domain name.
 
 Options
 -------
 
-.. option:: -a number-or-mnemonic, --algorithm=number-or-mnemonic
+.. option:: -a <NUMBER OR MNEMONIC>, --algorithm <NUMBER OR MNEMONIC>
 
       Use the given algorithm number for the hash calculation. Defaults to
-      ``sha1``.
+      1 (SHA-1).
 
-.. option:: -s salt, --salt=count
+.. option:: -i <NUMBER>, -t <NUMBER>, --iterations <NUMBER>
+
+      Use the given number of additional iterations for the hash calculation.
+
+.. option:: -s <HEX STRING>>, --salt <HEX STRING>>
 
       Use the given salt for the hash calculation. The salt value should be
       in hexadecimal format.
-
-.. option:: -i count, -t count, --iterations=count
-
-      Use *count* iterations for the hash calculation.
 

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -1,10 +1,10 @@
-dnst-nsec3-hash
+dnst nsec3-hash
 ===============
 
 Synopsis
 --------
 
-:program:`dnst nsec3-hash` [``OPTIONS``] ``<DOMAIN NAME>``
+:program:`dnst nsec3-hash` ``[OPTIONS]`` ``<DOMAIN NAME>``
 
 Description
 -----------

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -23,7 +23,7 @@ Options
 
       Use the given number of additional iterations for the hash calculation.
 
-.. option:: -s <HEX STRING>>, --salt <HEX STRING>>
+.. option:: -s <HEX STRING>, --salt <HEX STRING>
 
       Use the given salt for the hash calculation. The salt value should be
       in hexadecimal format.

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -22,7 +22,7 @@ Options
 .. option:: -i <NUMBER>, -t <NUMBER>, --iterations <NUMBER>
 
       Use the given number of additional iterations for the hash
-      calculation. Defaults to 0.
+      calculation. Defaults to 1.
 
 .. option:: -s <HEX STRING>, --salt <HEX STRING>
 

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -1,22 +1,22 @@
-dnst-signzone
+dnst signzone
 ===============
 
 Synopsis
 --------
 
-:program:`dnst signzone` [``OPTIONS``] ``<ZONEFILE>`` ``<KEY>...``
+:program:`dnst signzone` ``[OPTIONS]`` ``<ZONEFILE>`` ``<KEY>...``
 
 Description
 -----------
 
-**dnst signzone** signs the zone with the given key(s).
+**dnst signzone** signs the zonefile with the given key(s).
 
 Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
 i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
 ``.key`` files are required.
 
 A date can be a timestamp (seconds since the epoch), or of the form
-<YYYYMMdd[hhmmss]>.
+``<YYYYMMdd[hhmmss]>``.
 
 
 Options
@@ -28,20 +28,20 @@ Options
 
 .. option:: <KEY>...
 
-      The keys to sign the zone with.
+      The keys to sign the zonefile with.
 
 .. option:: -b
 
-      Use a more readable layout in the signed zone file and print comments on
-      DNSSEC records.
+      Add comments on DNSSEC records.
 
 .. option:: -d
 
-      Do not add used keys to the resulting zone file.
+      Do not add used keys to the resulting zonefile.
 
 .. option:: -e <DATE>
 
-      Set the expiration date. Defaults to 4 weeks from now.
+      Set the expiration date of signatures to this date. Defaults to
+      4 weeks from now.
 
 .. option:: -f <FILE>
 
@@ -50,7 +50,7 @@ Options
 
 .. option:: -i <DATE>
 
-      Set the inception date. Defaults to now.
+      Set the inception date of signatures to this date. Defaults to now.
 
 .. option:: -o <domain>
 
@@ -96,7 +96,7 @@ NSEC3 options for use with ``-n``.
 
 .. option:: -s <STRING>
 
-      Specify the salt. Defaults to ``-``, meaning no salt.
+      Specify the salt as a hex string. Defaults to ``-``, meaning no salt.
 
 .. option:: -p
 

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -15,10 +15,6 @@ Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
 i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
 ``.key`` files are required.
 
-A date can be a timestamp (seconds since the epoch), or of the form
-``<YYYYMMdd[hhmmss]>``.
-
-
 Options
 -------
 
@@ -41,8 +37,8 @@ Options
 
 .. option:: -e <DATE>
 
-      Set the expiration date of signatures to this date. Defaults to
-      4 weeks from now.
+      Set the expiration date of signatures to this date (see
+      :ref:`dnst-signzone-dates`). Defaults to 4 weeks from now.
 
 .. option:: -f <FILE>
 
@@ -51,7 +47,8 @@ Options
 
 .. option:: -i <DATE>
 
-      Set the inception date of signatures to this date. Defaults to now.
+      Set the inception date of signatures to this date (see
+      :ref:`dnst-signzone-dates`). Defaults to now.
 
 .. option:: -o <DOMAIN>
 
@@ -99,7 +96,7 @@ settings used.
 
 .. option:: -s <STRING>
 
-      Specify the salt as a hex string. Defaults to ``-``, meaning no salt.
+      Specify the salt as a hex string. Defaults to ``-``, meaning empty salt.
 
 .. option:: -p
 
@@ -109,3 +106,10 @@ settings used.
 
       Set the opt-out flag on all NSEC3 RRs and skip unsigned delegations.
 
+.. _dnst-signzone-dates:
+
+DATES
+-----
+
+A date can be a UNIX timestamp as seconds since the Epoch (1970-01-01
+00:00 UTC), or of the form ``<YYYYMMdd[hhmmss]>``.

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -32,7 +32,8 @@ Options
 
 .. option:: -b
 
-      Add comments on DNSSEC records.
+      Add comments on DNSSEC records. Without this option only DNSKEY RRs
+      will have their key tag annotated in the comment.
 
 .. option:: -d
 
@@ -52,10 +53,10 @@ Options
 
       Set the inception date of signatures to this date. Defaults to now.
 
-.. option:: -o <domain>
+.. option:: -o <DOMAIN>
 
-      Set the origin for the zone (for zonefiles with relative names and no
-      $ORIGIN).
+      Set the origin for the zone (only necessary for zonefiles with relative
+      names and no $ORIGIN).
 
 .. option:: -u
 
@@ -66,8 +67,9 @@ Options
 
 .. option:: -n
 
-      Use NSEC3 instead of NSEC. If specified, you can use extra options (see
-      :ref:`dnst-signzone-nsec3-options`).
+      Use NSEC3 instead of NSEC. By default, RFC 9276 best practice settings
+      are used: SHA-1, no extra iterations, empty salt. To use different NSEC3
+      settings see :ref:`dnst-signzone-nsec3-options`.
 
 .. option:: -H
 
@@ -84,9 +86,10 @@ Options
 NSEC3 options
 --------------------------------
 
-NSEC3 options for use with ``-n``.
+The following options can be used with ``-n`` to override the default NSEC3
+settings used.
 
-.. option:: -a <ALGORITHM>
+.. option:: -a <ALGORITHM NUMBER OR MNEMONIC>
 
       Specify the hashing algorithm. Defaults to SHA-1.
 

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -92,7 +92,7 @@ settings used.
 
 .. option:: -t <NUMBER>
 
-      Set the number of hash iterations. Defaults to 0.
+      Set the number of extra hash iterations. Defaults to 0.
 
 .. option:: -s <STRING>
 

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -15,8 +15,8 @@ Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
 i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
 ``.key`` files are required.
 
-Options
--------
+Arguments
+---------
 
 .. option:: <ZONEFILE>
 
@@ -25,6 +25,9 @@ Options
 .. option:: <KEY>...
 
       The keys to sign the zonefile with.
+
+Options
+-------
 
 .. option:: -b
 

--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -1,0 +1,108 @@
+dnst-signzone
+===============
+
+Synopsis
+--------
+
+:program:`dnst signzone` [``OPTIONS``] ``<ZONEFILE>`` ``<KEY>...``
+
+Description
+-----------
+
+**dnst signzone** signs the zone with the given key(s).
+
+Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
+i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
+``.key`` files are required.
+
+A date can be a timestamp (seconds since the epoch), or of the form
+<YYYYMMdd[hhmmss]>.
+
+
+Options
+-------
+
+.. option:: <ZONEFILE>
+
+      The zonefile to sign.
+
+.. option:: <KEY>...
+
+      The keys to sign the zone with.
+
+.. option:: -b
+
+      Use a more readable layout in the signed zone file and print comments on
+      DNSSEC records.
+
+.. option:: -d
+
+      Do not add used keys to the resulting zone file.
+
+.. option:: -e <DATE>
+
+      Set the expiration date. Defaults to 4 weeks from now.
+
+.. option:: -f <FILE>
+
+      Write signed zone to file. Use ``-f -`` to output to stdout. Defaults to
+      ``<ZONEFILE>.signed``.
+
+.. option:: -i <DATE>
+
+      Set the inception date. Defaults to now.
+
+.. option:: -o <domain>
+
+      Set the origin for the zone (for zonefiles with relative names and no
+      $ORIGIN).
+
+.. option:: -u
+
+      Set SOA serial to the number of seconds since Jan 1st 1970.
+
+      If this would NOT result in the SOA serial increasing it will be
+      incremented instead.
+
+.. option:: -n
+
+      Use NSEC3 instead of NSEC. If specified, you can use extra options (see
+      :ref:`dnst-signzone-nsec3-options`).
+
+.. option:: -H
+
+      Hash only, don't sign.
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).
+
+
+.. _dnst-signzone-nsec3-options:
+
+NSEC3 options
+--------------------------------
+
+NSEC3 options for use with ``-n``.
+
+.. option:: -a <ALGORITHM>
+
+      Specify the hashing algorithm. Defaults to SHA-1.
+
+.. option:: -t <NUMBER>
+
+      Set the number of hash iterations. Defaults to 0.
+
+.. option:: -s <STRING>
+
+      Specify the salt. Defaults to ``-``, meaning no salt.
+
+.. option:: -p
+
+      Set the opt-out flag on all NSEC3 RRs.
+
+.. option:: -A
+
+      Set the opt-out flag on all NSEC3 RRs and skip unsigned delegations.
+

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -1,0 +1,46 @@
+dnst-update
+===============
+
+Synopsis
+--------
+
+:program:`dnst update` ``<DOMAIN NAME>`` ``[<ZONE>]`` ``<IP>``
+``[<TSIG KEY NAME> <TSIG ALGORITHM> <TSIG KEY DATA>]``
+
+Description
+-----------
+
+**dnst update** sends a dynamic update packet to update an IP (or delete all
+existing IPs) for a domain name.
+
+Options
+-------
+
+.. option:: <DOMAIN NAME>
+
+      The domain name to update the IP address of
+
+.. option:: <ZONE>
+
+      The zone to send the update to (if omitted, derived from SOA record)
+
+.. option:: <IP>
+
+      The IP to update the domain with (``none`` to remove any existing IPs)
+
+.. option:: <TSIG KEY NAME>
+
+      TSIG key name
+
+.. option:: <TSIG ALGORITHM>
+
+      TSIG algorithm (e.g. "hmac-sha256")
+
+.. option:: <TSIG KEY DATA>
+
+      Base64 encoded TSIG key data.
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -1,4 +1,4 @@
-dnst-update
+dnst update
 ===============
 
 Synopsis

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -4,7 +4,7 @@ dnst update
 Synopsis
 --------
 
-:program:`dnst update` ``<DOMAIN NAME>`` ``[<ZONE>]`` ``<IP>``
+:program:`dnst update` ``<DOMAIN NAME>`` ``[ZONE]`` ``<IP>``
 ``[<TSIG KEY NAME> <TSIG ALGORITHM> <TSIG KEY DATA>]``
 
 Description
@@ -13,8 +13,8 @@ Description
 **dnst update** sends a dynamic update packet to update an IP (or delete all
 existing IPs) for a domain name.
 
-Options
--------
+Arguments
+---------
 
 .. option:: <DOMAIN NAME>
 

--- a/doc/manual/source/man/dnst.rst
+++ b/doc/manual/source/man/dnst.rst
@@ -11,8 +11,8 @@ Description
 
 Manage various aspects of the Domain Name System (DNS).
 
-dnst provides a number of commands that perform various tasks related
-managing DNS server and DNS zones.
+**dnst** provides a number of commands that perform various tasks related to
+managing DNS servers and DNS zones.
 
 Please consult the manual pages for these individual commands for more
 information.
@@ -22,7 +22,26 @@ dnst Commands
 
 .. glossary::
 
+   :doc:`dnst-key2ds <dnst-key2ds>` (1)
+
+        Generate DS RRs from the DNSKEYs in a keyfile.
+
+   :doc:`dnst-keygen <dnst-keygen>` (1)
+
+        Generate a new key pair for a domain name.
+
+   :doc:`dnst-notify <dnst-notify>` (1)
+
+        Send a NOTIFY message to a list of name servers.
+
    :doc:`dnst-nsec3-hash <dnst-nsec3-hash>` (1)
 
-        Prints the NSEC3 hash for a domain name.
+        Print out the NSEC3 hash of a domain name.
 
+   :doc:`dnst-signzone <dnst-signzone>` (1)
+
+        Sign the zone with the given key(s).
+
+   :doc:`dnst-update <dnst-update>` (1)
+
+        Send a dynamic update packet to update an IP (or delete all existing IPs) for a domain name.

--- a/doc/manual/source/man/dnst.rst
+++ b/doc/manual/source/man/dnst.rst
@@ -4,7 +4,7 @@ dnst
 Synopsis
 --------
 
-:program:`dnst` [``options``] ``command`` [``args``]
+:program:`dnst` ``[OPTIONS]`` ``<COMMAND>`` ``[ARGS]``
 
 Description
 -----------

--- a/doc/manual/source/man/ldns-key2ds.rst
+++ b/doc/manual/source/man/ldns-key2ds.rst
@@ -4,7 +4,7 @@ ldns-key2ds
 Synopsis
 --------
 
-:program:`ldns-key2ds` [``OPTIONS``] ``<KEYFILE>``
+:program:`ldns-key2ds` ``[OPTIONS]`` ``<KEYFILE>``
 
 Description
 -----------

--- a/doc/manual/source/man/ldns-key2ds.rst
+++ b/doc/manual/source/man/ldns-key2ds.rst
@@ -1,0 +1,43 @@
+ldns-key2ds
+===============
+
+Synopsis
+--------
+
+:program:`ldns-key2ds` [``OPTIONS``] ``<KEYFILE>``
+
+Description
+-----------
+
+**ldns-key2ds** is used to transform a public DNSKEY RR to a DS RR.  When run
+it will read ``<KEYFILE>`` with a DNSKEY RR in it, and it will create a .ds
+file with the DS RR in it.
+
+It prints out the basename for this file (``K<name>+<alg>+<id>``).
+
+By default, it takes a pick of algorithm similar to the key algorithm,
+SHA1 for RSASHA1, and so on.
+
+
+Options
+-------
+
+.. option:: -f
+
+      Ignore SEP flag (i.e. make DS records for any key)
+
+.. option:: -n
+
+      Write the result DS Resource Record to stdout instead of a file
+
+.. option:: -1
+
+      Use SHA1 as the hash function.
+
+.. option:: -2
+
+      Use SHA256 as the hash function
+
+.. option:: -4
+
+      Use SHA383 as the hash function

--- a/doc/manual/source/man/ldns-keygen.rst
+++ b/doc/manual/source/man/ldns-keygen.rst
@@ -1,0 +1,59 @@
+ldns-keygen
+===============
+
+Synopsis
+--------
+
+:program:`ldns-keygen` [``OPTIONS``] ``<DOMAIN NAME>``
+
+Description
+-----------
+
+**ldns-keygen** is used to generate a private/public keypair. When run, it will
+create 3 files; a .key file with the public DNSKEY, a .private file with the
+private keydata and a .ds file with the DS record of the DNSKEY record.
+
+.. **ldns-keygen** can also be used to create symmetric keys (for TSIG) by
+.. selecting the appropriate algorithm: hmac-md5.sig-alg.reg.int, hmac-sha1,
+.. hmac-sha224, hmac-sha256, hmac-sha384 or hmac-sha512. In that case no DS record
+.. will be created and no .ds file.
+
+ldns-keygen prints the basename for the key files: K<name>+<alg>+<id>
+
+Options
+-------
+
+.. option:: -a <algorithm>
+
+      Create a key with this algorithm. Specifying 'list' here gives a list of
+      supported algorithms. Several alias names are also accepted (from older
+      versions and other software), the list gives names from the RFC. Also the
+      plain algo number is accepted.
+
+.. option:: -b <bits>
+
+      Use this many bits for the key length.
+
+.. option:: -k
+
+      When given, generate a key signing key. This just sets the flag field to
+      257 instead of 256 in the DNSKEY RR in the .key file.
+
+.. option:: -r device
+
+      Make ldns-keygen use this file to seed the random generator with. This
+      will default to /dev/random.
+
+.. option:: -s
+
+      ldns-keygen will create symbolic links named **.private** to the new
+      generated private key, **.key** to the public DNSKEY and **.ds** to the
+      file containing DS record data.
+
+.. option:: -f
+
+      Force symlinks to be overwritten if they exist.
+
+.. option:: -v
+
+      Show the version and exit

--- a/doc/manual/source/man/ldns-keygen.rst
+++ b/doc/manual/source/man/ldns-keygen.rst
@@ -4,33 +4,34 @@ ldns-keygen
 Synopsis
 --------
 
-:program:`ldns-keygen` [``OPTIONS``] ``<DOMAIN NAME>``
+:program:`ldns-keygen` ``[OPTIONS]`` ``<DOMAIN NAME>``
 
 Description
 -----------
 
 **ldns-keygen** is used to generate a private/public keypair. When run, it will
-create 3 files; a .key file with the public DNSKEY, a .private file with the
-private keydata and a .ds file with the DS record of the DNSKEY record.
+create 3 files; a ``.key`` file with the public DNSKEY, a ``.private`` file
+with the private keydata and a ``.ds`` file with the DS record of the DNSKEY
+record.
 
 .. **ldns-keygen** can also be used to create symmetric keys (for TSIG) by
 .. selecting the appropriate algorithm: hmac-md5.sig-alg.reg.int, hmac-sha1,
 .. hmac-sha224, hmac-sha256, hmac-sha384 or hmac-sha512. In that case no DS record
 .. will be created and no .ds file.
 
-ldns-keygen prints the basename for the key files: K<name>+<alg>+<id>
+ldns-keygen prints the basename for the key files: ``K<name>+<alg>+<id>``
 
 Options
 -------
 
-.. option:: -a <algorithm>
+.. option:: -a <ALGORITHM>
 
       Create a key with this algorithm. Specifying 'list' here gives a list of
       supported algorithms. Several alias names are also accepted (from older
       versions and other software), the list gives names from the RFC. Also the
-      plain algo number is accepted.
+      plain algorithm number is accepted.
 
-.. option:: -b <bits>
+.. option:: -b <BITS>
 
       Use this many bits for the key length.
 
@@ -39,15 +40,15 @@ Options
       When given, generate a key signing key. This just sets the flag field to
       257 instead of 256 in the DNSKEY RR in the .key file.
 
-.. option:: -r device
+.. option:: -r <DEVICE>
 
       Make ldns-keygen use this file to seed the random generator with. This
       will default to /dev/random.
 
 .. option:: -s
 
-      ldns-keygen will create symbolic links named **.private** to the new
-      generated private key, **.key** to the public DNSKEY and **.ds** to the
+      ldns-keygen will create symbolic links named ``.private`` to the new
+      generated private key, ``.key`` to the public DNSKEY and ``.ds`` to the
       file containing DS record data.
 
 .. option:: -f

--- a/doc/manual/source/man/ldns-notify.rst
+++ b/doc/manual/source/man/ldns-notify.rst
@@ -1,0 +1,60 @@
+ldns-notify
+===============
+
+Synopsis
+--------
+
+:program:`ldns-notify` [``OPTIONS``] ``-z <ZONE>`` ``<SERVERS>...``
+
+Description
+-----------
+
+**ldns-notify** sends a NOTIFY packet to the specified name servers. A name
+server can be specified as a domain name or IP address.
+
+This tells them that an updated zone is available at the primaries. It can
+perform TSIG signatures, and it can add a SOA serial number of the updated
+zone. If a server already has that serial number it will disregard the message.
+
+Options
+-------
+
+.. option:: -z <ZONE>
+
+      The zone that is updated.
+
+.. ..option:: -I <ADDRESS>
+..
+..       Source IP to send the message from.
+
+.. option:: -s <SOA VERSION>
+
+      Append a SOA record indicating the serial number of the updated zone.
+
+.. option:: -p <PORT>
+
+      Destination port to send the UDP packet to. Defaults to 53.
+
+.. option:: -y <name:key[:algo]>
+
+      A base64 TSIG key and optional algorithm to use for the NOTIFY message.
+      The algorithm defaults to hmac-sha512.
+
+.. option:: -d
+
+      Print verbose debug information. The query that is sent and the query
+      that is received.
+
+.. option:: -r <RETRIES>
+
+      Specify the maximum number of retries before notify gives up trying to
+      send the UDP packet.
+
+.. option:: -h
+
+      Print the help text and exit.
+
+.. option:: -v
+
+      Print the version and exit.
+

--- a/doc/manual/source/man/ldns-notify.rst
+++ b/doc/manual/source/man/ldns-notify.rst
@@ -4,7 +4,7 @@ ldns-notify
 Synopsis
 --------
 
-:program:`ldns-notify` [``OPTIONS``] ``-z <ZONE>`` ``<SERVERS>...``
+:program:`ldns-notify` ``[OPTIONS]`` ``-z <ZONE>`` ``<SERVERS>...``
 
 Description
 -----------
@@ -35,7 +35,7 @@ Options
 
       Destination port to send the UDP packet to. Defaults to 53.
 
-.. option:: -y <name:key[:algo]>
+.. option:: -y <NAME:KEY[:ALGO]>
 
       A base64 TSIG key and optional algorithm to use for the NOTIFY message.
       The algorithm defaults to hmac-sha512.

--- a/doc/manual/source/man/ldns-nsec3-hash.rst
+++ b/doc/manual/source/man/ldns-nsec3-hash.rst
@@ -1,0 +1,29 @@
+ldns-nsec3-hash
+===============
+
+Synopsis
+--------
+
+:program:`ldns-nsec3-hash` :samp:`<{domain-name}>`
+
+Description
+-----------
+
+**ldns-nsec3-hash** is used to print out the NSEC3 hash for the given domain name.
+
+Options
+-------
+
+.. option:: -a number
+
+      Use the given algorithm number for the hash calculation. Defaults to
+      1 (SHA-1).
+
+.. option:: -s salt
+
+      Use the given salt for the hash calculation. The salt value should be
+      in hexadecimal format.
+
+.. option:: -t count
+
+      Use count iterations for the hash calculation.

--- a/doc/manual/source/man/ldns-nsec3-hash.rst
+++ b/doc/manual/source/man/ldns-nsec3-hash.rst
@@ -4,7 +4,7 @@ ldns-nsec3-hash
 Synopsis
 --------
 
-:program:`ldns-nsec3-hash` :samp:`<{domain-name}>`
+:program:`ldns-nsec3-hash` ``[OPTIONS]`` ``<DOMAIN NAME>``
 
 Description
 -----------
@@ -14,16 +14,16 @@ Description
 Options
 -------
 
-.. option:: -a number
+.. option:: -a <NUMBER>
 
       Use the given algorithm number for the hash calculation. Defaults to
       1 (SHA-1).
 
-.. option:: -s salt
+.. option:: -s <SALT>
 
       Use the given salt for the hash calculation. The salt value should be
       in hexadecimal format.
 
-.. option:: -t count
+.. option:: -t <COUNT>
 
       Use count iterations for the hash calculation.

--- a/doc/manual/source/man/ldns-nsec3-hash.rst
+++ b/doc/manual/source/man/ldns-nsec3-hash.rst
@@ -22,8 +22,9 @@ Options
 .. option:: -s <SALT>
 
       Use the given salt for the hash calculation. The salt value should be
-      in hexadecimal format.
+      in hexadecimal format. Defaults to an empty salt.
 
 .. option:: -t <COUNT>
 
-      Use count iterations for the hash calculation.
+      Use the given number of additional iterations for the hash
+      calculation. Defaults to 1.

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -1,0 +1,99 @@
+ldns-signzone
+===============
+
+Synopsis
+--------
+
+:program:`ldns-signzone` [``OPTIONS``] ``<ZONEFILE>`` ``<KEY>...``
+
+Description
+-----------
+
+**ldns-signzone** signs the zone with the given key(s).
+
+Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
+i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
+``.key`` files are required.
+
+A date can be a timestamp (seconds since the epoch), or of the form
+<YYYYMMdd[hhmmss]>.
+
+
+Options
+-------
+
+.. option:: <ZONEFILE>
+
+      The zonefile to sign.
+
+.. option:: <KEY>...
+
+      The keys to sign the zone with.
+
+.. option:: -b
+
+      Use a more readable layout in the signed zone file and print comments on
+      DNSSEC records.
+
+.. option:: -d
+
+      Do not add used keys to the resulting zone file.
+
+.. option:: -e <DATE>
+
+      Set the expiration date. Defaults to 4 weeks from now.
+
+.. option:: -f <FILE>
+
+      Write signed zone to file. Use ``-f -`` to output to stdout. Defaults to
+      ``<ZONEFILE>.signed``.
+
+.. option:: -i <DATE>
+
+      Set the inception date. Defaults to now.
+
+.. option:: -o <domain>
+
+      Set the origin for the zone (for zonefiles with relative names and no
+      $ORIGIN).
+
+.. option:: -u
+
+      Set SOA serial to the number of seconds since Jan 1st 1970.
+
+.. option:: -n
+
+      Use NSEC3 instead of NSEC. If specified, you can use extra options (see
+      :ref:`ldns-signzone-nsec3-options`).
+
+.. option:: -h
+
+      Print the help text.
+
+.. option:: -v
+
+      Print the version and exit.
+
+
+.. _ldns-signzone-nsec3-options:
+
+NSEC3 options
+--------------------------------
+
+NSEC3 options for use with ``-n``.
+
+.. option:: -a <ALGORITHM>
+
+      Specify the hashing algorithm. Defaults to SHA-1.
+
+.. option:: -t <NUMBER>
+
+      Set the number of hash iterations. Defaults to 0.
+
+.. option:: -s <STRING>
+
+      Specify the salt. Defaults to ``-``, meaning no salt.
+
+.. option:: -p
+
+      Set the opt-out flag on all NSEC3 RRs.

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -90,7 +90,7 @@ settings used.
 
 .. option:: -t <NUMBER>
 
-      Set the number of hash iterations. Defaults to 0.
+      Set the number of extra hash iterations. Defaults to 0.
 
 .. option:: -s <STRING>
 

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -15,12 +15,8 @@ Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
 i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
 ``.key`` files are required.
 
-A date can be a unix timestamp (seconds since the epoch), or of the form
-``<YYYYMMdd[hhmmss]>``.
-
-
-Options
--------
+Arguments
+---------
 
 .. option:: <ZONEFILE>
 
@@ -29,6 +25,9 @@ Options
 .. option:: <KEY>...
 
       The keys to sign the zonefile with.
+
+Options
+-------
 
 .. option:: -b
 
@@ -41,8 +40,8 @@ Options
 
 .. option:: -e <DATE>
 
-      Set the expiration date of signatures to this date. Defaults to
-      4 weeks from now.
+      Set the expiration date of signatures to this date (see
+      :ref:`ldns-signzone-dates`). Defaults to 4 weeks from now.
 
 .. option:: -f <FILE>
 
@@ -51,7 +50,8 @@ Options
 
 .. option:: -i <DATE>
 
-      Set the inception date of signatures to this date. Defaults to now.
+      Set the inception date of signatures to this date (see
+      :ref:`ldns-signzone-dates`). Defaults to now.
 
 .. option:: -o <DOMAIN>
 
@@ -94,8 +94,16 @@ settings used.
 
 .. option:: -s <STRING>
 
-      Specify the salt as a hex string. Defaults to ``-``, meaning no salt.
+      Specify the salt as a hex string. Defaults to ``-``, meaning empty salt.
 
 .. option:: -p
 
       Set the opt-out flag on all NSEC3 RRs.
+
+.. _ldns-signzone-dates:
+
+DATES
+-----
+
+A date can be a UNIX timestamp as seconds since the Epoch (1970-01-01
+00:00 UTC), or of the form ``<YYYYMMdd[hhmmss]>``.

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -90,7 +90,7 @@ settings used.
 
 .. option:: -t <NUMBER>
 
-      Set the number of extra hash iterations. Defaults to 0.
+      Set the number of extra hash iterations. Defaults to 1.
 
 .. option:: -s <STRING>
 

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -32,7 +32,8 @@ Options
 
 .. option:: -b
 
-      Add comments on DNSSEC records.
+      Add comments on DNSSEC records. Without this option only DNSKEY RRs
+      will have their key tag annotated in the comment.
 
 .. option:: -d
 
@@ -54,8 +55,8 @@ Options
 
 .. option:: -o <DOMAIN>
 
-      Set the origin for the zone (for zonefiles with relative names and no
-      $ORIGIN).
+      Set the origin for the zone (only necessary for zonefiles with
+      relative names and no $ORIGIN).
 
 .. option:: -u
 
@@ -80,7 +81,8 @@ Options
 NSEC3 options
 --------------------------------
 
-NSEC3 options for use with ``-n``.
+The following options can be used with ``-n`` to override the default NSEC3
+settings used.
 
 .. option:: -a <ALGORITHM>
 

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -4,7 +4,7 @@ ldns-signzone
 Synopsis
 --------
 
-:program:`ldns-signzone` [``OPTIONS``] ``<ZONEFILE>`` ``<KEY>...``
+:program:`ldns-signzone` ``[OPTIONS]`` ``<ZONEFILE>`` ``<KEY>...``
 
 Description
 -----------
@@ -15,8 +15,8 @@ Keys must be specified by their base name (usually ``K<name>+<alg>+<id>``),
 i.e. WITHOUT the ``.private`` or ``.key`` extension. Both ``.private`` and
 ``.key`` files are required.
 
-A date can be a timestamp (seconds since the epoch), or of the form
-<YYYYMMdd[hhmmss]>.
+A date can be a unix timestamp (seconds since the epoch), or of the form
+``<YYYYMMdd[hhmmss]>``.
 
 
 Options
@@ -28,20 +28,20 @@ Options
 
 .. option:: <KEY>...
 
-      The keys to sign the zone with.
+      The keys to sign the zonefile with.
 
 .. option:: -b
 
-      Use a more readable layout in the signed zone file and print comments on
-      DNSSEC records.
+      Add comments on DNSSEC records.
 
 .. option:: -d
 
-      Do not add used keys to the resulting zone file.
+      Do not add used keys to the resulting zonefile.
 
 .. option:: -e <DATE>
 
-      Set the expiration date. Defaults to 4 weeks from now.
+      Set the expiration date of signatures to this date. Defaults to
+      4 weeks from now.
 
 .. option:: -f <FILE>
 
@@ -50,9 +50,9 @@ Options
 
 .. option:: -i <DATE>
 
-      Set the inception date. Defaults to now.
+      Set the inception date of signatures to this date. Defaults to now.
 
-.. option:: -o <domain>
+.. option:: -o <DOMAIN>
 
       Set the origin for the zone (for zonefiles with relative names and no
       $ORIGIN).
@@ -92,7 +92,7 @@ NSEC3 options for use with ``-n``.
 
 .. option:: -s <STRING>
 
-      Specify the salt. Defaults to ``-``, meaning no salt.
+      Specify the salt as a hex string. Defaults to ``-``, meaning no salt.
 
 .. option:: -p
 

--- a/doc/manual/source/man/ldns-update.rst
+++ b/doc/manual/source/man/ldns-update.rst
@@ -1,0 +1,46 @@
+ldns-update
+===============
+
+Synopsis
+--------
+
+:program:`ldns-update` ``<DOMAIN NAME>`` ``[<ZONE>]`` ``<IP>``
+``[<TSIG KEY NAME> <TSIG ALGORITHM> <TSIG KEY DATA>]``
+
+Description
+-----------
+
+**ldns-update** sends a dynamic update packet to update an IP (or delete all
+existing IPs) for a domain name.
+
+Options
+-------
+
+.. option:: <DOMAIN NAME>
+
+      The domain name to update the IP address of
+
+.. option:: <ZONE>
+
+      The zone to send the update to (if omitted, derived from SOA record)
+
+.. option:: <IP>
+
+      The IP to update the domain with (``none`` to remove any existing IPs)
+
+.. option:: <TSIG KEY NAME>
+
+      TSIG key name
+
+.. option:: <TSIG ALGORITHM>
+
+      TSIG algorithm (e.g. "hmac-sha256")
+
+.. option:: <TSIG KEY DATA>
+
+      Base64 encoded TSIG key data.
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).

--- a/doc/manual/source/man/ldns-update.rst
+++ b/doc/manual/source/man/ldns-update.rst
@@ -4,7 +4,7 @@ ldns-update
 Synopsis
 --------
 
-:program:`ldns-update` ``<DOMAIN NAME>`` ``[<ZONE>]`` ``<IP>``
+:program:`ldns-update` ``<DOMAIN NAME>`` ``[ZONE]`` ``<IP>``
 ``[<TSIG KEY NAME> <TSIG ALGORITHM> <TSIG KEY DATA>]``
 
 Description


### PR DESCRIPTION
Adds manual pages for the six commands based on the help output (of dnst and ldns) and the ldns manuals. I only included arguments actually supported by the dnst reimplementation. Once everything is ready, this will very likely need updating.

This also incorporates and updates the changes from #25.