### PR TITLE
[error] Add 'bail' and 'ensure' macros

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -188,11 +188,11 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr, $fmt:expr) => {
-        if !$cond { $crate::error::bail!($fmt) }
+        if !$cond { $crate::error::bail!($fmt); }
     };
 
     ($cond:expr, $fmt:expr, $($args:tt)*) => {
-        if !$cond { $crate::error::bail!($fmt, $($args)*) }
+        if !$cond { $crate::error::bail!($fmt, $($args)*); }
     };
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -158,6 +158,30 @@ impl fmt::Debug for Error {
 
 impl error::Error for Error {}
 
+//------------ Macros --------------------------------------------------------
+
+/// Return an [`Error`] from the current function.
+macro_rules! bail {
+    ($fmt:expr) => {
+        return Err($crate::error::Error::new(&format!($fmt)));
+    };
+
+    ($fmt:expr, $($args:tt)*) => {
+        return Err($crate::error::Error::new(&format!($fmt, $($args)*)));
+    };
+}
+
+/// Return an [`Error`] if the given condition does not hold.
+macro_rules! ensure {
+    ($cond:expr, $fmt:expr) => {
+        if !$cond { $crate::error::bail!($fmt) }
+    };
+
+    ($cond:expr, $fmt:expr, $($args:tt)*) => {
+        if !$cond { $crate::error::bail!($fmt, $($args)*) }
+    };
+}
+
 //------------ Result --------------------------------------------------------
 
 /// A program result.

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,10 @@ impl error::Error for Error {}
 
 //------------ Macros --------------------------------------------------------
 
+// NOTE: Exported macros are placed in the crate root by default.  We hide
+// them using 'doc(hidden)' and then manually re-export them here, forcing
+// documentation to appear using 'doc(inline)'.
+
 #[doc(inline)]
 pub use crate::bail;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,7 +160,15 @@ impl error::Error for Error {}
 
 //------------ Macros --------------------------------------------------------
 
+#[doc(inline)]
+pub use crate::bail;
+
+#[doc(inline)]
+pub use crate::ensure;
+
 /// Return an [`Error`] from the current function.
+#[doc(hidden)]
+#[macro_export]
 macro_rules! bail {
     ($fmt:expr) => {
         return Err($crate::error::Error::new(&format!($fmt)));
@@ -172,6 +180,8 @@ macro_rules! bail {
 }
 
 /// Return an [`Error`] if the given condition does not hold.
+#[doc(hidden)]
+#[macro_export]
 macro_rules! ensure {
     ($cond:expr, $fmt:expr) => {
         if !$cond { $crate::error::bail!($fmt) }


### PR DESCRIPTION
These are quite useful for quickly creating and returning errors.  They're essentially equivalents of `panic!()` and `assert!()` respectively.