### PR TITLE
Error reporting extensions.

### DIFF
--- a/src/env/fake.rs
+++ b/src/env/fake.rs
@@ -51,11 +51,11 @@ impl Env for FakeEnv {
     }
 
     fn stdout(&self) -> Stream<impl fmt::Write> {
-        Stream(self.stdout.clone())
+        Stream::new(self.stdout.clone(), false)
     }
 
     fn stderr(&self) -> Stream<impl fmt::Write> {
-        Stream(self.stderr.clone())
+        Stream::new(self.stderr.clone(), false)
     }
 
     fn in_cwd<'a>(&self, path: &'a impl AsRef<Path>) -> Cow<'a, Path> {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -10,13 +10,10 @@ pub mod fake;
 
 pub use real::RealEnv;
 
+pub const RED: u8 = 31;
+pub const YELLOW: u8 = 33;
+
 pub trait Env {
-    // /// Make a network connection
-    // fn make_connection(&self);
-
-    // /// Make a new [`StubResolver`]
-    // fn make_stub_resolver(&self);
-
     /// Get an iterator over the command line arguments passed to the program
     ///
     /// Equivalent to [`std::env::args_os`]
@@ -32,9 +29,6 @@ pub trait Env {
     /// Equivalent to [`std::io::stderr`]
     fn stderr(&self) -> Stream<impl fmt::Write>;
 
-    // /// Get a reference to stdin
-    // fn stdin(&self) -> impl io::Read;
-
     fn in_cwd<'a>(&self, path: &'a impl AsRef<Path>) -> Cow<'a, Path>;
 }
 
@@ -44,28 +38,55 @@ pub trait Env {
 /// [`std::io::Write`]. Additionally, this `write_fmt` does not return a
 /// result. This means that we can use the [`write!`] and [`writeln`] macros
 /// without handling errors.
-pub struct Stream<T: fmt::Write>(T);
+pub struct Stream<T: fmt::Write> {
+    writer: T,
+    is_terminal: bool,
+}
 
 impl<T: fmt::Write> Stream<T> {
+    pub fn new(writer: T, is_terminal: bool) -> Self {
+        Self {
+            writer,
+            is_terminal,
+        }
+    }
+
     pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) {
         // This unwrap is not _really_ safe, but we are using this as stdout.
         // The `println` macro also ignores errors and `push_str` of the
         // fake stream also does not return an error. If this fails, it means
         // we can't write to stdout anymore so a graceful exit will be very
         // hard anyway.
-        self.0.write_fmt(args).unwrap();
+        self.writer.write_fmt(args).unwrap();
+    }
+
+    pub fn write_str(&mut self, s: &str) {
+        // Same as with write_fmt...
+        self.writer.write_str(s).unwrap();
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
+
+    pub fn colourize(&self, colour_code: u8, text: &str) -> String {
+        // 1B is the ASCII C0 ESC control code that introduces an ANSI escape
+        // sequence, 31 is the ANSI escape sequence for setting the terminal
+        // foreground colour to red, and 0 resets all attributes to their
+        // defaults.
+        //
+        // See:
+        //   - https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
+        //   - https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+        if self.is_terminal {
+            format!("\x1B[{colour_code}m{text}\x1B[0m")
+        } else {
+            text.to_string()
+        }
     }
 }
 
 impl<E: Env> Env for &E {
-    // fn make_connection(&self) {
-    //     todo!()
-    // }
-
-    // fn make_stub_resolver(&self) {
-    //     todo!()
-    // }
-
     fn args_os(&self) -> impl Iterator<Item = OsString> {
         (**self).args_os()
     }

--- a/src/env/real.rs
+++ b/src/env/real.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fmt;
-use std::io;
+use std::io::{self, IsTerminal};
 use std::path::Path;
 
 use super::Env;
@@ -15,11 +15,11 @@ impl Env for RealEnv {
     }
 
     fn stdout(&self) -> Stream<impl fmt::Write> {
-        Stream(FmtWriter(io::stdout()))
+        Stream::new(FmtWriter(io::stdout()), io::stdout().is_terminal())
     }
 
     fn stderr(&self) -> Stream<impl fmt::Write> {
-        Stream(FmtWriter(io::stderr()))
+        Stream::new(FmtWriter(io::stderr()), io::stderr().is_terminal())
     }
 
     fn in_cwd<'a>(&self, path: &'a impl AsRef<Path>) -> std::borrow::Cow<'a, std::path::Path> {


### PR DESCRIPTION
This builds on the work already done by @bal-e to:

- Determine the terminal status from the actual stream an error is written to.
- Factor out colourisation to the stream which knows if it is a terminal or not.
- Add support for yellow warnings as well as red errors.
- Add a line break at the end of written errors/warnings.
