### PR TITLE
all: remove Command::from implementations

### DIFF
--- a/src/commands/key2ds.rs
+++ b/src/commands/key2ds.rs
@@ -15,8 +15,9 @@ use lexopt::Arg;
 
 use crate::env::Env;
 use crate::error::Error;
+use crate::Args;
 
-use super::LdnsCommand;
+use super::{Command, LdnsCommand};
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 #[command(version)]
@@ -78,7 +79,7 @@ Options:
 impl LdnsCommand for Key2ds {
     const HELP: &'static str = LDNS_HELP;
 
-    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Self, Error> {
+    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         let mut ignore_sep = false;
         let mut write_to_stdout = false;
         let mut algorithm = None;
@@ -110,7 +111,7 @@ impl LdnsCommand for Key2ds {
             return Err("No keyfile given".into());
         };
 
-        Ok(Self {
+        Ok(Args::from(Command::Key2ds(Self {
             ignore_sep,
             write_to_stdout,
             algorithm,
@@ -118,7 +119,7 @@ impl LdnsCommand for Key2ds {
             // present in the ldns version of this command.
             force_overwrite: true,
             keyfile: keyfile.into(),
-        })
+        })))
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,9 +6,6 @@ pub mod nsec3hash;
 use std::ffi::{OsStr, OsString};
 use std::str::FromStr;
 
-use key2ds::Key2ds;
-use nsec3hash::Nsec3Hash;
-
 use crate::env::Env;
 use crate::Args;
 
@@ -50,28 +47,16 @@ impl Command {
 /// The [`LdnsCommand::parse_ldns`] function should parse arguments and
 /// return an error in case of a parsing failure. The help string provided
 /// as [`LdnsCommand::HELP`] is automatically appended to returned errors.
-pub trait LdnsCommand: Into<Command> {
+pub trait LdnsCommand {
     const HELP: &'static str;
 
-    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Self, Error>;
+    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error>;
 
     fn parse_ldns_args<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         match Self::parse_ldns(args) {
-            Ok(c) => Ok(Args::from(c.into())),
+            Ok(c) => Ok(c),
             Err(e) => Err(format!("Error: {e}\n\n{}", Self::HELP).into()),
         }
-    }
-}
-
-impl From<Nsec3Hash> for Command {
-    fn from(val: Nsec3Hash) -> Self {
-        Command::Nsec3Hash(val)
-    }
-}
-
-impl From<Key2ds> for Command {
-    fn from(val: Key2ds) -> Self {
-        Command::Key2ds(val)
     }
 }
 

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -10,8 +10,9 @@ use lexopt::Arg;
 
 use crate::env::Env;
 use crate::error::Error;
+use crate::Args;
 
-use super::{parse_os, parse_os_with, LdnsCommand};
+use super::{parse_os, parse_os_with, Command, LdnsCommand};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Nsec3Hash {
@@ -61,7 +62,7 @@ ldns-nsec3-hash [OPTIONS] <domain name>
 impl LdnsCommand for Nsec3Hash {
     const HELP: &'static str = LDNS_HELP;
 
-    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Self, Error> {
+    fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         let mut algorithm = Nsec3HashAlg::SHA1;
         let mut iterations = 1;
         let mut salt = Nsec3Salt::empty();
@@ -103,12 +104,12 @@ impl LdnsCommand for Nsec3Hash {
             return Err("Missing domain name argument".into());
         };
 
-        Ok(Self {
+        Ok(Args::from(Command::Nsec3Hash(Self {
             algorithm,
             iterations,
             salt,
             name,
-        })
+        })))
     }
 }
 


### PR DESCRIPTION
This feels slightly more simple and less magical and ultimately requires less code.

This also opens up something else: we could make a "report" command that can be generated by all ldns commands, which they can use to print their version. Because the function now does not return `Self` but `Args` that can be done. But I'll leave that for another PR.