### PR TITLE
All: add version printing mechanism via `Report` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "ldns"
 path = "src/bin/ldns.rs"
 
 [dependencies]
-clap = { version = "4.3.4", features = ["derive"] }
+clap = { version = "4.3.4", features = ["cargo", "derive"] }
 domain = { version = "0.10.3", git = "https://github.com/NLnetLabs/domain.git", branch = "initial-nsec3-generation", features = ["unstable-validator", "zonefile"] }
 lexopt = "0.3.0"
 

--- a/src/commands/key2ds.rs
+++ b/src/commands/key2ds.rs
@@ -77,7 +77,9 @@ Options:
 ";
 
 impl LdnsCommand for Key2ds {
+    const NAME: &'static str = "key2ds";
     const HELP: &'static str = LDNS_HELP;
+    const COMPATIBLE_VERSION: &'static str = "1.8.4";
 
     fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         let mut ignore_sep = false;
@@ -100,6 +102,7 @@ impl LdnsCommand for Key2ds {
                     }
                     keyfile = Some(val);
                 }
+                Arg::Short('v') => return Ok(Self::report_version()),
                 Arg::Short(x) => return Err(format!("Invalid short option: -{x}").into()),
                 Arg::Long(x) => {
                     return Err(format!("Long options are not supported, but `--{x}` given").into())

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -60,7 +60,9 @@ ldns-nsec3-hash [OPTIONS] <domain name>
 ";
 
 impl LdnsCommand for Nsec3Hash {
+    const NAME: &'static str = "nsec3-hash";
     const HELP: &'static str = LDNS_HELP;
+    const COMPATIBLE_VERSION: &'static str = "1.8.4";
 
     fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         let mut algorithm = Nsec3HashAlg::SHA1;


### PR DESCRIPTION
The command cannot be triggered via clap but can be returned by the routines that do ldns parsing. So they can print stuff without being executed. This allows them to print things and exit in a way that we can mock.