### PR TITLE
[keygen] Correct lists of supported algorithms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
       run: cargo clippy --all-features --all-targets -- -D warnings
     - if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
       run: cargo fmt --all -- --check
-    - run: cargo check --no-default-features --all-targets
+    - run: cargo check --no-default-features -F ring --all-targets
+    - run: cargo check --no-default-features -F openssl --all-targets
     - run: cargo test --all-features
 
   minimal-versions:


### PR DESCRIPTION
- Now, a compilation error occurs if both the `ring` and `openssl` features are disabled.
- ED448 is only listed as a supported algorithm when `openssl` is enabled.

At @ximon18's suggestion.