### PR TITLE
Re-order dnst commands alphabetically.

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -83,9 +83,9 @@ pub enum Command {
 impl Command {
     pub fn execute(self, env: impl Env) -> Result<(), Error> {
         match self {
+            Self::Key2ds(key2ds) => key2ds.execute(env),
             Self::Keygen(keygen) => keygen.execute(env),
             Self::Nsec3Hash(nsec3hash) => nsec3hash.execute(env),
-            Self::Key2ds(key2ds) => key2ds.execute(env),
             Self::Notify(notify) => notify.execute(env),
             Self::Update(update) => update.execute(env),
             Self::Help(help) => help.execute(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,6 +45,14 @@ pub enum Command {
     #[command(name = "keygen", verbatim_doc_comment)]
     Keygen(self::keygen::Keygen),
 
+    /// Generate a DS RR from the DNSKEYS in keyfile
+    ///
+    /// The following file will be created for each key:
+    /// `K<name>+<alg>+<id>.ds`. The base name `K<name>+<alg>+<id>`
+    /// will be printed to stdout.
+    #[command(name = "key2ds")]
+    Key2ds(key2ds::Key2ds),
+
     /// Print the NSEC3 hash of a given domain name
     #[command(name = "nsec3-hash")]
     Nsec3Hash(self::nsec3hash::Nsec3Hash),
@@ -56,14 +64,6 @@ pub enum Command {
     /// that serial number it will disregard the message.
     #[command(name = "notify")]
     Notify(self::notify::Notify),
-
-    /// Generate a DS RR from the DNSKEYS in keyfile
-    ///
-    /// The following file will be created for each key:
-    /// `K<name>+<alg>+<id>.ds`. The base name `K<name>+<alg>+<id>`
-    /// will be printed to stdout.
-    #[command(name = "key2ds")]
-    Key2ds(key2ds::Key2ds),
 
     /// Send an UPDATE packet
     #[command(name = "update")]


### PR DESCRIPTION
Currently `dnst` prints:

```
Usage: dnst <COMMAND>

Commands:
  keygen      Generate a new key pair for a given domain name
  nsec3-hash  Print the NSEC3 hash of a given domain name
  notify      Send a NOTIFY packet to DNS servers
  key2ds      Generate a DS RR from the DNSKEYS in keyfile
  update      Send an UPDATE packet
  help        Show the manual pages

Options:
  -h, --help     Print help
  -V, --version  Print version
```

`key2ds` in that list is out of alphabetical order.

This PR corrects that.