### PR TITLE
Remove license-file field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "Rust reimplementation of important ldns programs."
 categories = ["command-line-utilities"]
 license = "BSD-3-Clause"
-license-file = "LICENSE"
 keywords = ["DNS", "domain", "ldns"]
 rust-version = "1.79"
 


### PR DESCRIPTION
This field should only be used for non-standard license files.

This is specified by Cargo: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields

And also by, for example, Fedora:

> For this reason, the license metadata for all Rust crates packaged for Fedora MUST match the license tag of the Fedora package itself. Any crates that set package.license-file in their metadata (which is reserved for non-standard / non-SPDX licenses) MUST be patched to set package.license in their metadata instead in cases where this is not appropriate and an accurate SPDX expression can be provided. Patches like this SHOULD be submitted upstream.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Rust/#_crate_license