### PR TITLE
Fix up newlines in error printing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -83,9 +83,9 @@ impl Error {
             "ERROR:"
         };
 
-        write!(err, "[{prog}] {error_marker} {error}");
+        writeln!(err, "[{prog}] {error_marker} {error}");
         for context in &self.0.context {
-            writeln!(err, "\n... while {context}");
+            writeln!(err, "... while {context}");
         }
     }
 


### PR DESCRIPTION
The errors currently are printed without a newline, which is annoying because it requires us to add `\n` to every message. Additionally, there seemed to be a blank line between each context line.

@bal-e do you remember why you wrote it this way?

cc @Philip-NLnetLabs 