### PR TITLE
`nsec3-hash`: set default number of iterations to 0

### DIFF
--- a/doc/manual/source/man/ldns-nsec3-hash.rst
+++ b/doc/manual/source/man/ldns-nsec3-hash.rst
@@ -27,4 +27,6 @@ Options
 .. option:: -t <COUNT>
 
       Use the given number of additional iterations for the hash
-      calculation. Defaults to 1.
+      calculation. Defaults to 0. Note that this differs to the default value
+      used by the original `ldns-nsec3-hash` command to comply with latest
+      best practice per RFC 9276.

--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -67,7 +67,7 @@ impl LdnsCommand for Nsec3Hash {
 
     fn parse_ldns<I: IntoIterator<Item = OsString>>(args: I) -> Result<Args, Error> {
         let mut algorithm = Nsec3HashAlgorithm::SHA1;
-        let mut iterations = 1;
+        let mut iterations = 0;
         let mut salt = Nsec3Salt::empty();
         let mut name = None;
 
@@ -333,10 +333,10 @@ mod tests {
 
         #[test]
         fn accept_good_cli_args() {
-            assert_cmd_eq(&["nlnetlabs.nl"], "e3dbcbo05tvq0u7po4emvbu79c8vpcgk.\n");
+            assert_cmd_eq(&["nlnetlabs.nl"], "asqe4ap6479d7085ljcs10a2fpb2do94.\n");
             assert_cmd_eq(
                 &["-a", "1", "nlnetlabs.nl"],
-                "e3dbcbo05tvq0u7po4emvbu79c8vpcgk.\n",
+                "asqe4ap6479d7085ljcs10a2fpb2do94.\n",
             );
             assert_cmd_eq(
                 &["-t", "0", "nlnetlabs.nl"],
@@ -348,11 +348,11 @@ mod tests {
             );
             assert_cmd_eq(
                 &["-s", "", "nlnetlabs.nl"],
-                "e3dbcbo05tvq0u7po4emvbu79c8vpcgk.\n",
+                "asqe4ap6479d7085ljcs10a2fpb2do94.\n",
             );
             assert_cmd_eq(
                 &["-s", "DEADBEEF", "nlnetlabs.nl"],
-                "2h8rboqdrq0ard25vrmc4hjg7m56hnhd.\n",
+                "dfucs7bmmtsil9gij77k1kmocclg5d8a.\n",
             );
         }
 
@@ -391,6 +391,7 @@ mod tests {
             FakeCmd::new(["ldns-nsec3-hash"]).args(args).parse()
         }
 
+        #[track_caller]
         fn assert_cmd_eq(args: &[&str], expected_output: &str) {
             let result = FakeCmd::new(["ldns-nsec3-hash"]).args(args).run();
             assert_eq!(result.exit_code, 0);


### PR DESCRIPTION
This changes the default number of iterations of `ldns-nsec3-hash` ~to a more sensible default~ in accordance with latest best practice per RFC 9276. This explicitly breaks compatibility with the `ldns` version of this command.