### PR TITLE
Fix signing of zones with early glue.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.10.3"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=main#d06560824a7e25b3ec231be9b3019bb8c7841103"
+source = "git+https://github.com/NLnetLabs/domain.git?branch=fix-signing-with-early-glue#8d3730276a8d56ae2b94f660ee133e254bdc25b0"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ring = ["domain/ring"]
 bytes = "1.8.0"
 chrono = "0.4.38"
 clap = { version = "4.3.4", features = ["cargo", "derive"] }
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "fix-signing-with-early-glue", features = [
     "bytes",
     "net",
     "resolv",
@@ -59,7 +59,7 @@ const_format = " 0.2.33"
 test_bin = "0.4.0"
 tempfile = "3.14.0"
 regex = "1.11.1"
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "fix-signing-with-early-glue", features = [
     "unstable-stelline",
 ] }
 pretty_assertions = "1.4.1"

--- a/test-data/example.org.early-sorting-glue
+++ b/test-data/example.org.early-sorting-glue
@@ -1,0 +1,5 @@
+earlier-sorting.org.                  240 IN A    128.140.76.106
+example.org.                          240 IN SOA  example.net. hostmaster.example.net. 1234567890 28800 7200 604800 240
+example.org.                          240 IN NS   earlier-sorting.org.
+example.org.                          240 IN A    128.140.76.106
+some.example.org.                     240 IN A    1.1.1.1

--- a/test-data/example.org.early-sorting-glue-at-end
+++ b/test-data/example.org.early-sorting-glue-at-end
@@ -1,0 +1,5 @@
+example.org.                          240 IN SOA  example.net. hostmaster.example.net. 1234567890 28800 7200 604800 240
+example.org.                          240 IN NS   earlier-sorting.org.
+example.org.                          240 IN A    128.140.76.106
+some.example.org.                     240 IN A    1.1.1.1
+earlier-sorting.org.                  240 IN A    128.140.76.106

--- a/test-data/example.org.early-sorting-misnamed-glue
+++ b/test-data/example.org.early-sorting-misnamed-glue
@@ -1,0 +1,6 @@
+; This earlier-sorting.org glue record lacks the trailing period it should have.
+earlier-sorting.org                   240 IN A    128.140.76.106
+example.org.                          240 IN SOA  example.net. hostmaster.example.net. 1234567890 28800 7200 604800 240
+example.org.                          240 IN NS   earlier-sorting.org.
+example.org.                          240 IN A    128.140.76.106
+some.example.org.                     240 IN A    1.1.1.1

--- a/test-data/example.org.early-sorting-misnamed-glue-at-end
+++ b/test-data/example.org.early-sorting-misnamed-glue-at-end
@@ -1,0 +1,6 @@
+example.org.                          240 IN SOA  example.net. hostmaster.example.net. 1234567890 28800 7200 604800 240
+example.org.                          240 IN NS   earlier-sorting.org.
+example.org.                          240 IN A    128.140.76.106
+some.example.org.                     240 IN A    1.1.1.1
+; This earlier-sorting.org glue record lacks the trailing period it should have.
+earlier-sorting.org                  240 IN A    128.140.76.106


### PR DESCRIPTION
- Use updated domain which now requires that the apex of the zone being signed be passed to sign_zone(), rather than it failing to determine the right zone apex itself.
- Make `find_apex()` require the found apex to be the expected one when `-o` is in use and to only match SOA RRs at the root of a zone.
- Add some tests for the case of early glue showing that the wrong apex is no longer searched for a SOA by the signer.
- Remove the no longer necessary separation of execute() into an extra go_further() fn, which was previously needed as a workaround for using the right generic values.
- Some cleanup in affected/related code, e.g. bump the SOA SERIAL and use only that bumped SOA RR rather than use two different SOA RRs, and refer to `new_default_rr_ttl` instead of `soa_rr.ttl()` to make it clear that it's not per se the SOA RR TTL we are interested in, this is just the default we choose to use.

Note: currently depends on domain PR https://github.com/NLnetLabs/domain/pull/521.