### PR TITLE
Support signing of zones without `$ORIGIN` or `-o`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.10.3"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=main#2a390420af5f0f09f1a9bb31145844cb1409e163"
+source = "git+https://github.com/NLnetLabs/domain.git?branch=fx-inplace-parser-origin-detection#f6692ed373c51068d44dfb035d7cb00e7d66060d"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ring = ["domain/ring"]
 bytes = "1.8.0"
 chrono = "0.4.38"
 clap = { version = "4.3.4", features = ["cargo", "derive"] }
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "fx-inplace-parser-origin-detection", features = [
     "bytes",
     "net",
     "resolv",
@@ -58,7 +58,7 @@ const_format = " 0.2.33"
 test_bin = "0.4.0"
 tempfile = "3.14.0"
 regex = "1.11.1"
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "fx-inplace-parser-origin-detection", features = [
     "unstable-stelline",
 ] }
 pretty_assertions = "1.4.1"

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -2545,6 +2545,46 @@ mod test {
     }
 
     #[test]
+    fn do_not_add_keys_to_zone() {
+        let zone_file_path = mk_test_data_abs_path_string("test-data/example.rfc8976-simple");
+        let ksk_path = mk_test_data_abs_path_string("test-data/Kexample.+008+31967");
+        let zsk_path = mk_test_data_abs_path_string("test-data/Kexample.+008+38353");
+
+        let res1 = FakeCmd::new([
+            "dnst",
+            "signzone",
+            "-d",
+            "-f",
+            "-",
+            &zone_file_path,
+            &ksk_path,
+            &zsk_path,
+        ])
+        .run();
+
+        assert_eq!(res1.stderr, "");
+        assert_eq!(
+            res1.stdout,
+            "example.\t86400\tIN\tSOA\tns1.example. admin.example. 2018031900 1800 900 604800 86400\n\
+            example.\t86400\tIN\tNS\tns1.example.\n\
+            example.\t86400\tIN\tNS\tns2.example.\n\
+            example.\t86400\tIN\tRRSIG\tNS 8 1 86400 2419200 0 38353 example. Nf1AJOIse+BKTnng70iYOSazSo/PLZA3SAld/oOGqxE4g5ZTmfVa5ikHP8C+jBNaOW/nXNQJVc446pr1cI5kWVbKLbuPWKv33IygLVsOCKz8m8HIgihKxIcd0Wbzvsbgy4963wAo7ypde5mZ8+XDrLDNpcW8HKQMccZX1w63HF8=\n\
+            example.\t86400\tIN\tRRSIG\tSOA 8 1 86400 2419200 0 38353 example. GxHcCYArh7wmh/dpx95MVtAkc1soNSzw9OBmkvkG8gQiUwZSt5YJq8ImjRlzMQ+UQ/JfR6VGqpHdq/ScVgqOsXOYicn2430h4h1SebtWwwXnvkzWHCwSxVVInufQIRgZHfhhpNyjBxrSBwh2Y+qxnH2JYcrELQ28t0If7fo+tDM=\n\
+            example.\t86400\tIN\tRRSIG\tNSEC 8 1 86400 2419200 0 38353 example. ZooZy2FXylWuoy41yJt0XEFlllQNeuqnkb8of2HryRlDNbRwqARGzJxOUgCxJ6387w01lAiQJ3kMTHzz2U7FVwRh+mrtDUQ3SpIaH4iKNKyRUMAKJrrn2xhBtPg49bR/sHDfcIjRK67ktieYLKZqnPh636QaZFBjAk5ZXoG4g/8=\n\
+            example.\t86400\tIN\tNSEC\tns1.example. NS SOA RRSIG NSEC DNSKEY\n\
+            ns1.example.\t3600\tIN\tA\t203.0.113.63\n\
+            ns1.example.\t3600\tIN\tRRSIG\tA 8 2 3600 2419200 0 38353 example. BXRmu3njAbizxTX49isTcab9HR495sOrTYzq5nU71aEbY89lz8rdMhxLA6NYX0zIYJPHdkI7yf8/aHf2VsAjz+p2NQ7qaODtm5oFpIm2O9JiBqTrqj5P4fK9qN+pJmKsJAXupphXhFKmsQkWJdYCoHq/wXjq1Hp7xICdd30XsUY=\n\
+            ns1.example.\t86400\tIN\tRRSIG\tNSEC 8 2 86400 2419200 0 38353 example. G1ohioxllf2ZTVt4XrgKkCQ0JhxNZn4ABecihoHVVOpUNBlk4aWrdOtWTKt81dwbnXONhttL3sf6mWJJXJFe1yAxZAU3LA1wHlc+V50xjbO2vNW6oSQ9CjTBZW9/aih5aUtG4uTroa8din5eaUn1hL2DTOfG7bKKNfkH5wpU9vs=\n\
+            ns1.example.\t86400\tIN\tNSEC\tns2.example. A RRSIG NSEC\n\
+            ns2.example.\t3600\tIN\tAAAA\t2001:db8::63\n\
+            ns2.example.\t3600\tIN\tRRSIG\tAAAA 8 2 3600 2419200 0 38353 example. X566NNfPtSpPXdOfJT0XaMPcTHSvBKThjaCvodojDW6OLKfZJyvZOjzYcvMMLDcHkRkNak6M534Zn++Hrym3n2hl3FS/A1hGLMZ2MxlQxVwya4Xg9zE3IEmlRGlVFjVFrEK1Me8sfwyg+eM7+8Wq3qOtxyK/xb4eL8lmgB/kfm4=\n\
+            ns2.example.\t86400\tIN\tRRSIG\tNSEC 8 2 86400 2419200 0 38353 example. cM6oDa/FElsY5XuBa7LXwn35w7t2Dckya+9EVr3oxqKWrVCOemFXUCQkFv/DX2NA9IY1ijJkvDN+I2lg7XXhokFc78CpJeL/rr7EbxKQulKEy64u/Skd4ZuedLD6pQw21oIqFTnJ/nj1e3DXoWAEk2rGflexZ6E9NrxJrXYmTrA=\n\
+            ns2.example.\t86400\tIN\tNSEC\texample. AAAA RRSIG NSEC\n"
+        );
+        assert_eq!(res1.exit_code, 0);
+    }
+
+    #[test]
     fn zonemd_digest_and_replacing_existing_at_apex() {
         let dir = run_setup();
 

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -2545,7 +2545,7 @@ mod test {
     }
 
     #[test]
-    fn do_not_add_keys_to_zone() {
+    fn detect_origin_from_initial_absolute_name() {
         let zone_file_path = mk_test_data_abs_path_string("test-data/example.rfc8976-simple");
         let ksk_path = mk_test_data_abs_path_string("test-data/Kexample.+008+31967");
         let zsk_path = mk_test_data_abs_path_string("test-data/Kexample.+008+38353");
@@ -2553,7 +2553,6 @@ mod test {
         let res1 = FakeCmd::new([
             "dnst",
             "signzone",
-            "-d",
             "-f",
             "-",
             &zone_file_path,
@@ -2571,7 +2570,10 @@ mod test {
             example.\t86400\tIN\tRRSIG\tNS 8 1 86400 2419200 0 38353 example. Nf1AJOIse+BKTnng70iYOSazSo/PLZA3SAld/oOGqxE4g5ZTmfVa5ikHP8C+jBNaOW/nXNQJVc446pr1cI5kWVbKLbuPWKv33IygLVsOCKz8m8HIgihKxIcd0Wbzvsbgy4963wAo7ypde5mZ8+XDrLDNpcW8HKQMccZX1w63HF8=\n\
             example.\t86400\tIN\tRRSIG\tSOA 8 1 86400 2419200 0 38353 example. GxHcCYArh7wmh/dpx95MVtAkc1soNSzw9OBmkvkG8gQiUwZSt5YJq8ImjRlzMQ+UQ/JfR6VGqpHdq/ScVgqOsXOYicn2430h4h1SebtWwwXnvkzWHCwSxVVInufQIRgZHfhhpNyjBxrSBwh2Y+qxnH2JYcrELQ28t0If7fo+tDM=\n\
             example.\t86400\tIN\tRRSIG\tNSEC 8 1 86400 2419200 0 38353 example. ZooZy2FXylWuoy41yJt0XEFlllQNeuqnkb8of2HryRlDNbRwqARGzJxOUgCxJ6387w01lAiQJ3kMTHzz2U7FVwRh+mrtDUQ3SpIaH4iKNKyRUMAKJrrn2xhBtPg49bR/sHDfcIjRK67ktieYLKZqnPh636QaZFBjAk5ZXoG4g/8=\n\
+            example.\t86400\tIN\tRRSIG\tDNSKEY 8 1 86400 2419200 0 31967 example. ipF3HEK6J8wbb2mZL1eP15EyGa7OxwIDihkyKwEswbtKbwLxk0qKIJUz0BiTIqzzl1I+d93PpQTRfxJHGPYmf+KshkzwmeLOIdzMh2WZP9OpRXqofL1zw0RSoM+xxVZKCFJbFUSymwro+cdkpAva9KP+ZVcIudNIGtCz9sbhTEI=\n\
             example.\t86400\tIN\tNSEC\tns1.example. NS SOA RRSIG NSEC DNSKEY\n\
+            example.\t86400\tIN\tDNSKEY\t256 3 8 AwEAAbsD4Tcz8hl2Rldov4CrfYpK3ORIh/giSGDlZaDTZR4gpGxGvMBwu2jzQ3m0iX3PvqPoaybC4tznjlJi8g/qsCRHhOkqWmjtmOYOJXEuUTb+4tPBkiboJM5QchxTfKxkYbJ2AD+VAUX1S6h/0DI0ZCGx1H90QTBE2ymRgHBwUfBt\n\
+            example.\t86400\tIN\tDNSKEY\t257 3 8 AwEAAaYL5iwWI6UgSQVcDZmH7DrhQU/P6cOfi4wXYDzHypsfZ1D8znPwoAqhj54kTBVqgZDHw8QEnMcS3TWxvHBvncRTIXhCLx0BNK5/6mcTSK2IDbxl0j4vkcQrOxc77tyExuFfuXouuKVtE7rggOJiX6ga5LJW2if6Jxe/Rh8+aJv7\n\
             ns1.example.\t3600\tIN\tA\t203.0.113.63\n\
             ns1.example.\t3600\tIN\tRRSIG\tA 8 2 3600 2419200 0 38353 example. BXRmu3njAbizxTX49isTcab9HR495sOrTYzq5nU71aEbY89lz8rdMhxLA6NYX0zIYJPHdkI7yf8/aHf2VsAjz+p2NQ7qaODtm5oFpIm2O9JiBqTrqj5P4fK9qN+pJmKsJAXupphXhFKmsQkWJdYCoHq/wXjq1Hp7xICdd30XsUY=\n\
             ns1.example.\t86400\tIN\tRRSIG\tNSEC 8 2 86400 2419200 0 38353 example. G1ohioxllf2ZTVt4XrgKkCQ0JhxNZn4ABecihoHVVOpUNBlk4aWrdOtWTKt81dwbnXONhttL3sf6mWJJXJFe1yAxZAU3LA1wHlc+V50xjbO2vNW6oSQ9CjTBZW9/aih5aUtG4uTroa8din5eaUn1hL2DTOfG7bKKNfkH5wpU9vs=\n\

--- a/tests/signzone.rs
+++ b/tests/signzone.rs
@@ -10,9 +10,12 @@ use tempfile::tempdir;
 
 const LDNS_CMD: &str = "ldns-signzone";
 const TEST_DATA_DIR: &str = "test-data/";
-const TEST_ZONE_PATH: &str = concatcp!(TEST_DATA_DIR, "jelte.nlnetlabs.nl");
-const KSK_FILE_BASE_PATH: &str = concatcp!(TEST_DATA_DIR, "Kjelte.nlnetlabs.nl.+008+31310");
-const ZSK_FILE_BASE_PATH: &str = concatcp!(TEST_DATA_DIR, "Kjelte.nlnetlabs.nl.+008+19779");
+const JELTE_ZONE_PATH: &str = concatcp!(TEST_DATA_DIR, "jelte.nlnetlabs.nl");
+const JELTE_KSK_PATH: &str = concatcp!(TEST_DATA_DIR, "Kjelte.nlnetlabs.nl.+008+31310");
+const JELTE_ZSK_PATH: &str = concatcp!(TEST_DATA_DIR, "Kjelte.nlnetlabs.nl.+008+19779");
+const ORIGINLESS_ZONE_PATH: &str = concatcp!(TEST_DATA_DIR, "example.rfc8976-simple");
+const ORIGINLESS_KSK_PATH: &str = concatcp!(TEST_DATA_DIR, "Kexample.+008+31967");
+const ORIGINLESS_ZSK_PATH: &str = concatcp!(TEST_DATA_DIR, "Kexample.+008+38353");
 
 #[ignore = "should only be run if ldns command line tools are installed"]
 #[test]
@@ -27,16 +30,16 @@ fn signzone_only_zsk() {
             "-b",
             "-f",
             &ldns_out_path,
-            TEST_ZONE_PATH,
-            ZSK_FILE_BASE_PATH,
+            JELTE_ZONE_PATH,
+            JELTE_ZSK_PATH,
         ],
         &[
             LDNS_CMD,
             "-b",
             "-f",
             &dnst_out_path,
-            TEST_ZONE_PATH,
-            ZSK_FILE_BASE_PATH,
+            JELTE_ZONE_PATH,
+            JELTE_ZSK_PATH,
         ],
         false,
     );
@@ -57,16 +60,46 @@ fn signzone_only_ksk() {
             "-b",
             "-f",
             &ldns_out_path,
-            TEST_ZONE_PATH,
-            KSK_FILE_BASE_PATH,
+            JELTE_ZONE_PATH,
+            JELTE_KSK_PATH,
         ],
         &[
             LDNS_CMD,
             "-b",
             "-f",
             &dnst_out_path,
-            TEST_ZONE_PATH,
-            KSK_FILE_BASE_PATH,
+            JELTE_ZONE_PATH,
+            JELTE_KSK_PATH,
+        ],
+        false,
+    );
+
+    verify_signed_zone(dnst_out_path);
+}
+
+#[ignore = "should only be run if ldns command line tools are installed"]
+#[test]
+fn signzone_detect_origin() {
+    let temp_dir = tempdir().unwrap().into_path();
+    let ldns_out_path = format!("{}/ldns.signed", temp_dir.display());
+    let dnst_out_path = format!("{}/dnst.signed", temp_dir.display());
+
+    assert_org_ldns_cmd_eq_new_ldns_cmd(
+        &[
+            LDNS_CMD,
+            "-f",
+            &ldns_out_path,
+            ORIGINLESS_ZONE_PATH,
+            ORIGINLESS_KSK_PATH,
+            ORIGINLESS_ZSK_PATH
+        ],
+        &[
+            LDNS_CMD,
+            "-f",
+            &dnst_out_path,
+            ORIGINLESS_ZONE_PATH,
+            ORIGINLESS_KSK_PATH,
+            ORIGINLESS_ZSK_PATH
         ],
         false,
     );

--- a/tests/signzone.rs
+++ b/tests/signzone.rs
@@ -91,7 +91,7 @@ fn signzone_detect_origin() {
             &ldns_out_path,
             ORIGINLESS_ZONE_PATH,
             ORIGINLESS_KSK_PATH,
-            ORIGINLESS_ZSK_PATH
+            ORIGINLESS_ZSK_PATH,
         ],
         &[
             LDNS_CMD,
@@ -99,7 +99,7 @@ fn signzone_detect_origin() {
             &dnst_out_path,
             ORIGINLESS_ZONE_PATH,
             ORIGINLESS_KSK_PATH,
-            ORIGINLESS_ZSK_PATH
+            ORIGINLESS_ZSK_PATH,
         ],
         false,
     );


### PR DESCRIPTION
Depends on `domain` PR https://github.com/NLnetLabs/domain/pull/527.

With related unit and integration test that deliberately do not pass the `-o` argument (to specify the origin), instead requiring the zone parser to determine the origin from the initial `example.` owner, as `ldns-signzone` does. 

This PR merges into PR #8.