### PR TITLE
Add a test of '-u'.

### DIFF
--- a/src/commands/nsec3hash.rs
+++ b/src/commands/nsec3hash.rs
@@ -176,7 +176,7 @@ mod tests {
         use domain::rdata::nsec3::Nsec3Salt;
 
         use crate::commands::nsec3hash::Nsec3Hash;
-        use crate::env::fake::{FakeCmd, FakeEnv, FakeStream};
+        use crate::env::fake::{FakeCmd, FakeEnv};
 
         // Note: For the types we use that are provided by the domain crate,
         // construction of them from bad inputs should be tested in that
@@ -188,8 +188,9 @@ mod tests {
         fn execute() {
             let env = FakeEnv {
                 cmd: FakeCmd::new(["unused"]),
-                stdout: FakeStream::default(),
-                stderr: FakeStream::default(),
+                stdout: Default::default(),
+                stderr: Default::default(),
+                seconds_since_epoch: Default::default(),
                 stelline: None,
             };
 

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -2135,7 +2135,7 @@ mod test {
     use crate::env::fake::FakeCmd;
 
     use super::SignZone;
-    use crate::env::{Env, RealEnv};
+    use crate::env::Env;
 
     #[track_caller]
     fn parse(args: FakeCmd) -> SignZone {

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -4078,13 +4078,9 @@ xx.example.\t3600\tIN\tRRSIG\tNSEC 8 2 3600 20240101010101 20240101010101 38353 
         let ksk_path = mk_test_data_abs_path_string("test-data/Kexample.org.+008+51331");
         let zsk_path = mk_test_data_abs_path_string("test-data/Kexample.org.+008+28954");
 
-        // As the UNIX epoch timestamp 1234567890 (from the SOA SERIAL)
-        // represents a date and time in 2009, the UNIX timestamp for the time
-        // now will be a larger than the SOA SERIAL. Below override the time
-        // now in the FakeEnv used to use this mock time now instead. The code
-        // handling `-u` should thus overwrite the SOA SERIAL in the zone file
-        // with the one we provide.
-        let time_now = RealEnv.seconds_since_epoch();
+        // Simulate that the time now is later than the 1234567890 SOA SERIAL
+        // in the zonefile.
+        let time_now = 1234567891;
         let expected_soa_line = format!("example.org.\t238\tIN\tSOA\texample.net. hostmaster.example.net. {} 28800 7200 604800 239\n", time_now);
 
         let res = FakeCmd::new([
@@ -4113,9 +4109,8 @@ xx.example.\t3600\tIN\tRRSIG\tNSEC 8 2 3600 20240101010101 20240101010101 38353 
         let ksk_path = mk_test_data_abs_path_string("test-data/Kexample.org.+008+51331");
         let zsk_path = mk_test_data_abs_path_string("test-data/Kexample.org.+008+28954");
 
-        // As the UNIX epoch timestamp 1234567890 (from the SOA SERIAL), use a
-        // time that is older than that so that the code handling `-u` should
-        // then ignore it and instead increment the zone file SOA SERIAL.
+        // Simulate that the time now is earlier than the 1234567890 SOA
+        // SERIAL in the zonefile.
         let time_now = 1234567889;
         let expected_soa_line = "example.org.\t238\tIN\tSOA\texample.net. hostmaster.example.net. 1234567891 28800 7200 604800 239\n";
 

--- a/src/env/fake.rs
+++ b/src/env/fake.rs
@@ -194,7 +194,7 @@ impl FakeCmd {
                 .map(|s| (s, Arc::new(CurrStepValue::new()))),
         };
 
-        (env_modifier)(&mut env);
+        env_modifier(&mut env);
 
         let exit_code = run(&mut env);
 

--- a/src/env/fake.rs
+++ b/src/env/fake.rs
@@ -16,8 +16,8 @@ use domain::stelline::parse_stelline::{self, Stelline};
 use crate::error::Error;
 use crate::{parse_args, run, Args};
 
-use super::Env;
 use super::Stream;
+use super::{Env, RealEnv};
 
 /// A command to run in a [`FakeEnv`]
 ///
@@ -52,6 +52,9 @@ pub struct FakeEnv {
     /// The mocked stderr
     pub stderr: FakeStream,
 
+    /// The mocked current time, if any
+    pub seconds_since_epoch: Option<u32>,
+
     pub stelline: Option<(Stelline, Arc<CurrStepValue>)>,
 }
 
@@ -73,6 +76,17 @@ impl Env for FakeEnv {
             Some(cwd) => cwd.join(path).into(),
             None => path.as_ref().into(),
         }
+    }
+
+    fn seconds_since_epoch(&self) -> u32 {
+        match self.seconds_since_epoch {
+            Some(seconds) => seconds,
+            None => RealEnv.seconds_since_epoch(),
+        }
+    }
+
+    fn set_seconds_since_epoch(&mut self, seconds: u32) {
+        self.seconds_since_epoch = Some(seconds);
     }
 
     fn dgram(
@@ -157,6 +171,7 @@ impl FakeCmd {
             cmd: self.clone(),
             stdout: Default::default(),
             stderr: Default::default(),
+            seconds_since_epoch: None,
             stelline: None,
         };
         parse_args(env)
@@ -164,17 +179,24 @@ impl FakeCmd {
 
     /// Run the [`FakeCmd`] in a [`FakeEnv`], returning a [`FakeResult`]
     pub fn run(&self) -> FakeResult {
-        let env = FakeEnv {
+        self.run_with_modified_env(|_| {})
+    }
+
+    pub fn run_with_modified_env<F: Fn(&mut FakeEnv)>(&self, env_modifier: F) -> FakeResult {
+        let mut env = FakeEnv {
             cmd: self.clone(),
             stdout: Default::default(),
             stderr: Default::default(),
+            seconds_since_epoch: None,
             stelline: self
                 .stelline
                 .clone()
                 .map(|s| (s, Arc::new(CurrStepValue::new()))),
         };
 
-        let exit_code = run(&env);
+        (env_modifier)(&mut env);
+
+        let exit_code = run(&mut env);
 
         FakeResult {
             exit_code,

--- a/src/env/real.rs
+++ b/src/env/real.rs
@@ -9,6 +9,7 @@ use domain::resolv::StubResolver;
 
 use super::Env;
 use super::Stream;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Use real I/O
 pub struct RealEnv;
@@ -28,6 +29,19 @@ impl Env for RealEnv {
 
     fn in_cwd<'a>(&self, path: &'a impl AsRef<Path>) -> std::borrow::Cow<'a, std::path::Path> {
         path.as_ref().into()
+    }
+
+    fn seconds_since_epoch(&self) -> u32 {
+        let now = SystemTime::now();
+        let value = match now.duration_since(UNIX_EPOCH) {
+            Ok(value) => value,
+            Err(_) => UNIX_EPOCH.duration_since(now).unwrap(),
+        };
+        value.as_secs() as u32
+    }
+
+    fn set_seconds_since_epoch(&mut self, _seconds: u32) {
+        // NO OP
     }
 
     fn dgram(


### PR DESCRIPTION
That sets the SOA SERIAL to the Epoch time now if ahead of the SOA SERIAL, or increments the SOA SERIAL otherwise.

Changes the code that determines the serial now to do so with its own mockable source of time from the environment, instead of using `Serial::now()` which hard-codes use of the real system clock, and extends the concept of `Env` to support seconds since the epoch which can be overridden when using `FakeEnv`.