### PR TITLE
Minimally update `dnst signzone` man page.

### DIFF
--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -30,11 +30,6 @@ Arguments
 Options
 -------
 
-.. option:: -b
-
-      Add comments on DNSSEC records. Without this option only DNSKEY RRs
-      will have their key tag annotated in the comment.
-
 .. option:: -d
 
       Do not add used keys to the resulting zonefile.
@@ -66,6 +61,20 @@ Options
       If this would NOT result in the SOA serial increasing it will be
       incremented instead.
 
+.. option:: -n
+
+      Use NSEC3 instead of NSEC. By default, RFC 9276 best practice settings
+      are used: SHA-1, no extra iterations, empty salt. To use different NSEC3
+      settings see :ref:`dnst-signzone-nsec3-options`.
+
+.. option:: -A
+
+      Sign DNSKEYs with all keys instead of the minimal set.
+
+.. option:: -U
+
+      Sign with every unique algorithm in the provided keys.
+
 .. option:: -z <[SCHEME:]HASH>
 
       Add a ZONEMD resource record. Accepts both mnemonics and numbers.
@@ -80,14 +89,6 @@ Options
       Allow adding ZONEMD RRs without signing the zone. With this option, the
       <KEY>... argument becomes optional and determines whether to sign the
       zone.
-
-.. TODO: document -A and -U when implemented
-
-.. option:: -n
-
-      Use NSEC3 instead of NSEC. By default, RFC 9276 best practice settings
-      are used: SHA-1, no extra iterations, empty salt. To use different NSEC3
-      settings see :ref:`dnst-signzone-nsec3-options`.
 
 .. option:: -H
 
@@ -104,6 +105,36 @@ Options
       ``--help``).
 
 
+.. _dnst-signzone-formatting-options:
+
+Output formatting options
+--------------------------------
+
+The following options can be used to affect the format of the output.
+
+.. option:: -b
+
+      Add comments on DNSSEC records. Without this option only DNSKEY RRs
+      will have their key tag annotated in the comment.
+
+.. option:: -L
+
+      Preceed the zone output by a list that contains the NSEC3 hashes of the
+      original ownernames.
+
+.. option:: -O
+
+      Order NSEC3 RRs by unhashed owner name.
+
+.. option:: -R
+
+      Order RRSIG RRs by the record type that they cover.
+
+.. option:: -T
+
+      Output YYYYMMDDHHmmSS RRSIG timestamps instead of seconds since epoch.
+
+
 .. _dnst-signzone-nsec3-options:
 
 NSEC3 options
@@ -116,19 +147,19 @@ settings used.
 
       Specify the hashing algorithm. Defaults to SHA-1.
 
-.. option:: -t <NUMBER>
-
-      Set the number of extra hash iterations. Defaults to 0.
-
 .. option:: -s <STRING>
 
       Specify the salt as a hex string. Defaults to ``-``, meaning empty salt.
+
+.. option:: -t <NUMBER>
+
+      Set the number of extra hash iterations. Defaults to 0.
 
 .. option:: -p
 
       Set the opt-out flag on all NSEC3 RRs.
 
-.. option:: -A
+.. option:: -P
 
       Set the opt-out flag on all NSEC3 RRs and skip unsigned delegations.
 

--- a/doc/manual/source/man/ldns-signzone.rst
+++ b/doc/manual/source/man/ldns-signzone.rst
@@ -26,6 +26,10 @@ Arguments
       Note: Unlike the original LDNS, any existing NSEC(3), NSEC3PARAM and/or
       RRSIG resource records will be skipped when loading the zonefile.
 
+      Note: Unlike the original LDNS, the origin must be explicitly specified
+      either via an ``$ORIGIN`` directive in the zonefile or using the ``-o``
+      command line argument.
+
 .. option:: <KEY>...
 
       The keys to sign the zonefile with.

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -162,7 +162,6 @@ pub struct SignZone {
     #[arg(short = 'U', default_value_t = false)]
     sign_with_every_unique_algorithm: bool,
 
-    // This should be handled at the dnst top level, not per subcommand.
     /// Add a ZONEMD resource record
     ///
     /// <hash> currently supports "SHA384" (1) or "SHA512" (2).

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -150,7 +150,18 @@ pub struct SignZone {
     #[arg(short = 'u', default_value_t = false)]
     set_soa_serial_to_epoch_time: bool,
 
-    // SKIPPED: -v
+    /// Use NSEC3 instead of NSEC
+    #[arg(short = 'n', default_value_t = false, group = "nsec3")]
+    use_nsec3: bool,
+
+    /// Sign DNSKEYs with all keys instead of the minimal set
+    #[arg(short = 'A', default_value_t = false)]
+    sign_dnskeys_with_all_keys: bool,
+
+    /// Sign with every unique algorithm in the provided keys
+    #[arg(short = 'U', default_value_t = false)]
+    sign_with_every_unique_algorithm: bool,
+
     // This should be handled at the dnst top level, not per subcommand.
     /// Add a ZONEMD resource record
     ///
@@ -172,18 +183,6 @@ pub struct SignZone {
     /// Allow ZONEMDs to be added without signing
     #[arg(short = 'Z', requires = "zonemd")]
     allow_zonemd_without_signing: bool,
-
-    /// Sign DNSKEYs with all keys instead of minimal
-    #[arg(short = 'A', default_value_t = false)]
-    sign_dnskeys_with_all_keys: bool,
-
-    /// Sign with every unique algorithm in the provided keys
-    #[arg(short = 'U', default_value_t = false)]
-    sign_with_every_unique_algorithm: bool,
-
-    /// Use NSEC3 instead of NSEC
-    #[arg(short = 'n', default_value_t = false, group = "nsec3")]
-    use_nsec3: bool,
 
     /// Hashing algorithm
     #[arg(
@@ -247,14 +246,6 @@ pub struct SignZone {
     #[arg(short = 'M', default_value_t = false)]
     no_require_keys_match_apex: bool,
 
-    /// Output YYYYMMDDHHmmSS RRSIG timestamps instead of seconds since epoch.
-    #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
-        short = 'T',
-        default_value_t = false
-    )]
-    use_yyyymmddhhmmss_rrsig_format: bool,
-
     /// Preceed the zone output by a list that contains the NSEC3 hashes of the
     /// original ownernames.
     #[arg(
@@ -265,15 +256,6 @@ pub struct SignZone {
     )]
     preceed_zone_with_hash_list: bool,
 
-    /// Order RRSIG RRs by the record type that they cover.
-    #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
-        short = 'R',
-        default_value_t = false,
-        default_value_if("extra_comments", "true", Some("true")),
-    )]
-    order_rrsigs_after_the_rtype_they_cover: bool,
-
     /// Order NSEC3 RRs by unhashed owner name.
     #[arg(
         help_heading = Some("OUTPUT FORMATTING"),
@@ -283,6 +265,23 @@ pub struct SignZone {
         requires = "nsec3",
     )]
     order_nsec3_rrs_by_unhashed_owner_name: bool,
+
+    /// Order RRSIG RRs by the record type that they cover.
+    #[arg(
+        help_heading = Some("OUTPUT FORMATTING"),
+        short = 'R',
+        default_value_t = false,
+        default_value_if("extra_comments", "true", Some("true")),
+    )]
+    order_rrsigs_after_the_rtype_they_cover: bool,
+
+    /// Output YYYYMMDDHHmmSS RRSIG timestamps instead of seconds since epoch.
+    #[arg(
+        help_heading = Some("OUTPUT FORMATTING"),
+        short = 'T',
+        default_value_t = false
+    )]
+    use_yyyymmddhhmmss_rrsig_format: bool,
 
     // -----------------------------------------------------------------------
     // Original ldns-signzone positional arguments in position order:


### PR DESCRIPTION
Add missing arguments and re-order arguments to match `-h` output, plus some argument re-ordering to better group related arguments together in `-h` output.

This PR merges into PR #8.