### PR TITLE
Switch to a release version of domain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,12 +310,15 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "0.10.3"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=main#0c6c36ee4974bad580024ce5f78965d5d8aaefbe"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11dd7f04a6a6d2aea0153c6e31f5ea7af8b2efdf52cdaeea7a9a592c7fefef9"
 dependencies = [
  "arc-swap",
+ "bumpalo",
  "bytes",
  "chrono",
+ "domain-macros",
  "futures-util",
  "hashbrown",
  "libc",
@@ -333,6 +336,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "domain-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e197fdfd2cdb5fdeb7f8ddcf3aed5d5d04ecde2890d448b14ffb716f7376b70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -659,9 +673,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -685,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ring = ["domain/ring"]
 bytes = "1.8.0"
 chrono = "0.4.38"
 clap = { version = "4.3.4", features = ["cargo", "derive"] }
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
+domain = { version = "0.11.0", features = [
     "bytes",
     "net",
     "resolv",
@@ -49,6 +49,4 @@ _unused_lazy_static = { package = "lazy_static", version = "1.0.2" }
 test_bin = "0.4.0"
 tempfile = "3.14.0"
 regex = "1.11.1"
-domain = { git = "https://github.com/NLnetLabs/domain.git", branch = "main", features = [
-    "unstable-stelline",
-] }
+domain = { version = "0.11.0", features = ["unstable-stelline"] }


### PR DESCRIPTION
While this PR passes CI checks, it won't yet work for the `packaging` workflow as the Docker build will fail is it depends on not-yet-merged `domain` PR https://github.com/NLnetLabs/domain/pull/529.