### PR TITLE
Add support for -I to notify.

### DIFF
--- a/doc/manual/source/man/dnst-notify.rst
+++ b/doc/manual/source/man/dnst-notify.rst
@@ -23,6 +23,10 @@ Options
 
       The zone to send the NOTIFY for.
 
+.. option:: -I <ADDRESS>
+
+      Source IP to send the message from.
+
 .. option:: -s <SOA VERSION>
 
       SOA version number to include in the NOTIFY message.

--- a/doc/manual/source/man/ldns-notify.rst
+++ b/doc/manual/source/man/ldns-notify.rst
@@ -23,9 +23,9 @@ Options
 
       The zone that is updated.
 
-.. ..option:: -I <ADDRESS>
-..
-..       Source IP to send the message from.
+.. option:: -I <ADDRESS>
+
+       Source IP to send the message from.
 
 .. option:: -s <SOA VERSION>
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -363,7 +363,12 @@ impl Update {
         for name in nsnames {
             let found_ips = resolver.lookup_host(&name).await?;
             for socket in found_ips.port_iter(53) {
-                let dgram_connection = dgram::Connection::new(env.dgram(socket));
+                let local: SocketAddr = if socket.is_ipv4() {
+                    ([0u8; 4], 0).into()
+                } else {
+                    ([0u16; 8], 0).into()
+                };
+                let dgram_connection = dgram::Connection::new(env.dgram(local, socket));
 
                 let connection: Box<dyn SendRequest<_>> = if let Some(k) = &tsig_key {
                     Box::new(tsig::Connection::new(k.clone(), dgram_connection))

--- a/src/env/fake.rs
+++ b/src/env/fake.rs
@@ -18,6 +18,7 @@ use crate::{parse_args, run, Args};
 
 use super::Env;
 use super::Stream;
+use std::net::SocketAddr;
 
 /// A command to run in a [`FakeEnv`]
 ///
@@ -83,7 +84,8 @@ impl Env for FakeEnv {
 
     fn dgram(
         &self,
-        _addr: std::net::SocketAddr,
+        _src: SocketAddr,
+        _dst: SocketAddr,
     ) -> impl AsyncConnect<Connection: AsyncDgramRecv + AsyncDgramSend + Send + Sync + Unpin + 'static>
            + Clone
            + Send

--- a/src/env/fake.rs
+++ b/src/env/fake.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::ffi::OsString;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -18,7 +19,6 @@ use crate::{parse_args, run, Args};
 
 use super::Env;
 use super::Stream;
-use std::net::SocketAddr;
 
 /// A command to run in a [`FakeEnv`]
 ///

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -40,7 +40,8 @@ pub trait Env {
 
     fn dgram(
         &self,
-        socket: SocketAddr,
+        src: SocketAddr,
+        dest: SocketAddr,
     ) -> impl AsyncConnect<Connection: AsyncDgramRecv + AsyncDgramSend + Send + Sync + Unpin + 'static>
            + Clone
            + Send
@@ -132,13 +133,14 @@ impl<E: Env> Env for &E {
 
     fn dgram(
         &self,
-        socket: SocketAddr,
+        src: SocketAddr,
+        dest: SocketAddr,
     ) -> impl AsyncConnect<Connection: AsyncDgramRecv + AsyncDgramSend + Send + Sync + Unpin + 'static>
            + Clone
            + Send
            + Sync
            + 'static {
-        (**self).dgram(socket)
+        (**self).dgram(src, dest)
     }
 
     async fn stub_resolver_from_conf(&self, config: ResolvConf) -> StubResolver {

--- a/src/env/real.rs
+++ b/src/env/real.rs
@@ -1,11 +1,16 @@
+use core::future::Future;
+use core::pin::Pin;
+
 use std::ffi::OsString;
 use std::io::{self, IsTerminal};
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Mutex;
 
-use domain::net::client::protocol::{AsyncConnect, AsyncDgramRecv, AsyncDgramSend, UdpConnect};
+use domain::net::client::protocol::{AsyncConnect, AsyncDgramRecv, AsyncDgramSend};
 use domain::resolv::stub::conf::ResolvConf;
 use domain::resolv::StubResolver;
+use tokio::net::UdpSocket;
 
 use super::Env;
 use super::Stream;
@@ -40,16 +45,77 @@ impl Env for RealEnv {
 
     fn dgram(
         &self,
-        addr: std::net::SocketAddr,
+        src: SocketAddr,
+        dest: SocketAddr,
     ) -> impl AsyncConnect<Connection: AsyncDgramRecv + AsyncDgramSend + Send + Sync + Unpin + 'static>
            + Clone
            + Send
            + Sync
            + 'static {
-        UdpConnect::new(addr)
+        SpecificIpUdpConnect::new(src, dest)
     }
 
     async fn stub_resolver_from_conf(&self, config: ResolvConf) -> StubResolver {
         StubResolver::from_conf(config)
+    }
+}
+
+//-------- SpecficIpUdpConnect -----------------------------------------------
+//
+// Based on domain::net::client::protocol::UdpConnect.
+
+/// How many times do we try a new random port if we get ‘address in use.’
+const RETRY_RANDOM_PORT: usize = 10;
+
+/// Create new UDP connections from a specific local address.
+#[derive(Clone, Copy, Debug)]
+pub struct SpecificIpUdpConnect {
+    /// Local address to connect from.
+    src: SocketAddr,
+
+    /// Remote address to connect to.
+    dest: SocketAddr,
+}
+
+impl SpecificIpUdpConnect {
+    /// Create new UDP connections.
+    ///
+    /// src is the source address to connect from.
+    /// dest is the destination address to connect to.
+    ///
+    /// If the src port is 0 a random port will be chosen.
+    ///
+    /// If the src address is 0 local interface will be chosen.
+    pub fn new(src: SocketAddr, dest: SocketAddr) -> Self {
+        Self { src, dest }
+    }
+
+    /// Bind to a random local UDP port.
+    async fn bind_and_connect(self) -> Result<UdpSocket, io::Error> {
+        let mut i = 0;
+        let sock = loop {
+            match UdpSocket::bind(&self.src).await {
+                Ok(sock) => break sock,
+                Err(err) => {
+                    if i == RETRY_RANDOM_PORT {
+                        return Err(err);
+                    } else {
+                        i += 1
+                    }
+                }
+            }
+        };
+        sock.connect(self.dest).await?;
+        Ok(sock)
+    }
+}
+
+impl AsyncConnect for SpecificIpUdpConnect {
+    type Connection = UdpSocket;
+    type Fut =
+        Pin<Box<dyn Future<Output = Result<Self::Connection, std::io::Error>> + Send + Sync>>;
+
+    fn connect(&self) -> Self::Fut {
+        Box::pin(self.bind_and_connect())
     }
 }


### PR DESCRIPTION
Note: Rather than adding `SpecificIpUdpConnect` as this PR does it might be better to add a setter to `UdpConnect` in domain called `set_src(addr: SocketAddr)` and have it use the provided value, if any, else fallback to a v4 or v6 zero address otherwise.

Otherwise, a better name for `SpecificIpUdpConnect` might be `UdpConnectWithSourceAddr` or `UdpConnectFrom`.