### PR TITLE
Make version argument handling more consistent.

### DIFF
--- a/doc/manual/source/man/dnst-key2ds.rst
+++ b/doc/manual/source/man/dnst-key2ds.rst
@@ -39,7 +39,3 @@ Options
 
       Print the help text (short summary with ``-h``, long help with
       ``--help``).
-
-.. option:: -V, --version
-
-      Print the version.

--- a/doc/manual/source/man/dnst-nsec3-hash.rst
+++ b/doc/manual/source/man/dnst-nsec3-hash.rst
@@ -33,7 +33,3 @@ Options
 
       Print the help text (short summary with ``-h``, long help with
       ``--help``).
-
-.. option:: -V, --version
-
-      Print the version.

--- a/doc/manual/source/man/dnst.rst
+++ b/doc/manual/source/man/dnst.rst
@@ -17,8 +17,20 @@ managing DNS servers and DNS zones.
 Please consult the manual pages for these individual commands for more
 information.
 
-dnst Commands
--------------
+Options
+-------
+
+.. option:: -h, --help
+
+      Print the help text (short summary with ``-h``, long help with
+      ``--help``).
+
+.. option:: -V, --version
+
+      Print the version.
+
+Commands
+--------
 
 .. glossary::
 

--- a/src/commands/key2ds.rs
+++ b/src/commands/key2ds.rs
@@ -20,7 +20,6 @@ use crate::Args;
 use super::{Command, LdnsCommand};
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
-#[command(version)]
 pub struct Key2ds {
     /// ignore SEP flag (i.e. make DS records for any key)
     #[arg(long = "ignore-sep")]
@@ -103,7 +102,6 @@ impl LdnsCommand for Key2ds {
                     }
                     keyfile = Some(val);
                 }
-                Arg::Short('v') => return Ok(Self::report_version()),
                 Arg::Short(x) => return Err(format!("Invalid short option: -{x}").into()),
                 Arg::Long(x) => {
                     return Err(format!("Long options are not supported, but `--{x}` given").into())


### PR DESCRIPTION
Both across `dnst` subcommands and with the original ldns-xxx commands.

Also update man pages to more accurately reflect version argument behaviour.