### PR TITLE
Follow change in `domain` regarding vendoring of OpenSSL.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "lazy_static",
  "lexopt",
  "octseq",
+ "openssl",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -339,7 +340,7 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain.git?rev=bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e#bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e"
+source = "git+https://github.com/NLnetLabs/domain.git?rev=a3e7ab0bc248bada2c2564bf77ddc58010d4ce25#a3e7ab0bc248bada2c2564bf77ddc58010d4ce25"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -371,7 +372,7 @@ dependencies = [
 [[package]]
 name = "domain-macros"
 version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/domain.git?rev=bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e#bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e"
+source = "git+https://github.com/NLnetLabs/domain.git?rev=a3e7ab0bc248bada2c2564bf77ddc58010d4ce25#a3e7ab0bc248bada2c2564bf77ddc58010d4ce25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ ring = ["domain/ring"]
 
 # For building in a cargo cross container that lacks openssl-dev so cannot
 # successfully compile the Rust OpenSSL crate.
-static-openssl = ["domain/static-openssl"]
+static-openssl = ["openssl/vendored"]
 
 [dependencies]
 bytes = "1.8.0"
 chrono = "0.4.38"
 clap = { version = "4.3.4", features = ["cargo", "derive"] }
-domain = { git = "https://github.com/NLnetLabs/domain.git", rev = "bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", rev = "a3e7ab0bc248bada2c2564bf77ddc58010d4ce25", features = [
     "bytes",
     "net",
     "resolv",
@@ -40,13 +40,14 @@ domain = { git = "https://github.com/NLnetLabs/domain.git", rev = "bb6bd2b3f45fe
     "unstable-client-transport",
     "unstable-sign",
     "unstable-validator",
-    "unstable-zonetree",
+    "unstable-zonetree"
 ] }
 lexopt = "0.3.0"
 rayon = "1.10.0"
 octseq = "0.5.2"
 ring = "0.17.8"
 tokio = "1.40.0"
+openssl = { version = "*", features = ["vendored"], optional = true }
 
 # LDNS-xxx mode specific dependencies.
 # TODO: put these behind a feature gate?
@@ -64,7 +65,7 @@ const_format = " 0.2.33"
 test_bin = "0.4.0"
 tempfile = "3.20.0"
 regex = "1.11.1"
-domain = { git = "https://github.com/NLnetLabs/domain.git", rev = "bb6bd2b3f45fea8c00b6ef21e666d268e9d2e37e", features = [
+domain = { git = "https://github.com/NLnetLabs/domain.git", rev = "a3e7ab0bc248bada2c2564bf77ddc58010d4ce25", features = [
     "unstable-stelline",
 ] }
 pretty_assertions = "1.4.1"


### PR DESCRIPTION
This change seems to be enough to continue building `dnst` with vendored OpenSSL now that the `static-openssl` feature was removed from `domain`.

An alternate approach could be to see if we can make cross-compiled and Docker builds work without vendored OpenSSL, but perhaps that should be put as an issue to come back to later. 