### PR TITLE
Remove From<io::Error> impl for Error.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::io;
 
 use domain::base::wire::ParseError;
 use tracing::error;
@@ -113,12 +112,6 @@ impl From<String> for Error {
 
 impl From<fmt::Error> for Error {
     fn from(error: fmt::Error) -> Self {
-        Self::new(&error.to_string())
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Self {
         Self::new(&error.to_string())
     }
 }


### PR DESCRIPTION
Remove From<io::Error> impl for Error because context tends to get lost.