### PR TITLE
Remove NSEC3 algorithm option for dnst

### DIFF
--- a/doc/manual/source/man/dnst-signzone.rst
+++ b/doc/manual/source/man/dnst-signzone.rst
@@ -140,10 +140,6 @@ NSEC3 options
 The following options can be used with ``-n`` to override the default NSEC3
 settings used.
 
-.. option:: -a <ALGORITHM NUMBER OR MNEMONIC>
-
-      Specify the hashing algorithm. Defaults to SHA-1.
-
 .. option:: -s <STRING>
 
       Specify the salt as a hex string. Defaults to ``-``, meaning empty salt.

--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -186,14 +186,7 @@ pub struct SignZone {
     allow_zonemd_without_signing: bool,
 
     /// Hashing algorithm.
-    #[arg(
-        help_heading = Some("NSEC3 (when using '-n')"),
-        short = 'a',
-        value_name = "algorithm",
-        default_value = "SHA-1",
-        value_parser = ValueParser::new(Nsec3Hash::parse_nsec3_alg),
-        requires = "nsec3"
-    )]
+    #[arg(skip = Nsec3HashAlgorithm::SHA1)]
     algorithm: Nsec3HashAlgorithm,
 
     /// Number of hash iterations.


### PR DESCRIPTION
The NSEC3 algorithm option only had one possible value (SHA-1) and is therefore unnecessary.

Fixes #31