### PR TITLE
Adapt CI workflow from domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,12 +279,11 @@ jobs:
       #   # See <https://github.com/actions/runner-images/issues/12432>
       #   echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> "$GITHUB_ENV"
       id: vcpkg
-      uses: johnwason/vcpkg-action@v6
+      uses: johnwason/vcpkg-action@v7
       with:
         pkgs: openssl
         triplet: ${{ env.VCPKGRS_TRIPLET }}
         token: ${{ github.token }}
-        github-binarycache: true
 
     - name: Install OpenSSL
       if: matrix.os == 'ubuntu-latest'
@@ -396,12 +395,11 @@ jobs:
       #   mkdir -p .cargo
       #   printf '[target.x86_64-pc-windows-msvc]\nlinker = "rust-lld"\n' >> .cargo/config.toml
       id: vcpkg
-      uses: johnwason/vcpkg-action@v6
+      uses: johnwason/vcpkg-action@v7
       with:
         pkgs: openssl
         triplet: ${{ env.VCPKGRS_TRIPLET }}
         token: ${{ github.token }}
-        github-binarycache: true
 
     - name: Install OpenSSL
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,15 +269,6 @@ jobs:
     # Prepare the environment on Windows
     - name: Prepare Windows environment
       if: matrix.os == 'windows-latest'
-      # shell: bash
-      # run: |
-      #   # Cargo doesn't support enabling all but one feature, so determine the
-      #   # complete feature list and filter out 'openssl'.
-      #   features=`cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|select(.name == "dnst")|.features|keys|map(select(.!="openssl"))|join(",")'`
-      #   # Overwrite the 'DNST_FEATURES' environment variable.
-      #   echo "DNST_FEATURES=--features=$features" >> "$GITHUB_ENV"
-      #   # See <https://github.com/actions/runner-images/issues/12432>
-      #   echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> "$GITHUB_ENV"
       id: vcpkg
       uses: johnwason/vcpkg-action@v7
       with:
@@ -384,16 +375,6 @@ jobs:
     # Prepare the environment on Windows
     - name: Prepare Windows environment
       if: matrix.os == 'windows-latest'
-      # shell: bash
-      # run: |
-      #   # Cargo doesn't support enabling all but one feature, so determine the
-      #   # complete feature list and filter out 'openssl'.
-      #   features=`cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|select(.name == "dnst")|.features|keys|map(select(.!="openssl"))|join(",")'`
-      #   # Overwrite the 'DNST_FEATURES' environment variable.
-      #   echo "DNST_FEATURES=--features=$features" >> "$GITHUB_ENV"
-      #   # See <https://github.com/actions/runner-images/issues/12432>
-      #   mkdir -p .cargo
-      #   printf '[target.x86_64-pc-windows-msvc]\nlinker = "rust-lld"\n' >> .cargo/config.toml
       id: vcpkg
       uses: johnwason/vcpkg-action@v7
       with:
@@ -436,5 +417,3 @@ jobs:
           target/
         # Cache by OS and Rust version.
         key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
-
-# TODO: Use 'cargo-semver-checks' on releases.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,283 @@
-name: ci
-on: [push, pull_request]
-env:
-  RUSTFLAGS: "-D warnings"
+# ======================================================
+# Continuous Integration: making sure the codebase works
+# ======================================================
+#
+# This workflow tests modifications to 'dnst', ensuring that 'dnst' can be
+# used by others successfully.  It verifies certain aspects of the codebase,
+# such as the formatting and feature flag combinations, and runs the full test
+# suite.  It runs on Ubuntu, Mac OS, and Windows.
+
+name: CI
+
+# When the worflow runs
+# ---------------------
+on:
+  # Execute when a pull request is (re-) opened or its head changes (e.g. new
+  # commits are added or the commit history is rewritten) ... but only if
+  # build-related files change.
+  pull_request:
+    paths:
+      - '**.rs'
+      - 'Cargo.{toml,lock}'
+      - '.github/workflows/ci.yml'
+
+  # If a pull request is merged, at least one commit is added to the target
+  # branch.  If the target is another pull request, it will be caught by the
+  # above event.  We miss PRs that merge to a non-PR branch, except for the
+  # 'main' branch.
+
+  # Execute when a commit is pushed to 'main' (including merged PRs) or to a
+  # release tag ... but only if build-related files change.
+  push:
+    branches:
+      - 'main'
+      - 'releases/**'
+    paths:
+      - '**.rs'
+      - 'Cargo.{toml,lock}'
+      - '.github/workflows/ci.yml'
+
+  # Rebuild 'main' every week.  This will account for changes to dependencies
+  # and to Rust, either of which can trigger new failures.  Rust releases are
+  # every 6 weeks, on a Thursday; this event runs every Friday.
+  schedule:
+    - cron: '0 10 * * FRI'
+
+# Jobs
+# ----------------------------------------------------------------------------
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.79.0, stable, beta, nightly]
+
+  # Check Formatting
+  # ----------------
+  #
+  # NOTE: This job is run even if no '.rs' files have changed.  Inserting such
+  # a check would require using a separate workflow file or using third-party
+  # actions.  Most commits do change '.rs' files, and 'cargo-fmt' is pretty
+  # fast, so optimizing this is not necessary.
+  check-fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up the Rust toolchain.
+    #
+    # Disable the cache since it's not relevant for formatting.
+    - name: Set up Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt
+        cache: false
+
+    # Do the actual formatting check.
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+  # Determine MSRV
+  # --------------
+  #
+  # The MSRV needs to be determined as we will test 'dnst' against the Rust
+  # compiler at that version.
+  determine-msrv:
+    name: Determine MSRV
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.determine-msrv.outputs.msrv }}
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Determine the MSRV.
+    - name: Determine MSRV
+      id: determine-msrv
+      run: |
+        msrv=`cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|select(.name=="dnst")|.rust_version'`
+        echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
+
+  # Check Feature Flags
+  # -------------------
+  #
+  # Rust does not provide any way to check that all possible feature flag
+  # combinations will succeed, so we need to try them manually here.  We will
+  # assume this choice is not influenced by the OS or Rust version.
+  check-feature-flags:
+    name: Check feature flags
+    runs-on: ubuntu-latest
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        cache: false
+
+    - name: Install OpenSSL
+      run: sudo apt-get install -y libssl-dev
+
+    # Restore a cache of dependencies and 'target'.
+    - name: Restore a dependency cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+
+    # Do the actual feature flag checks.
+    # (--all-features is done in check-minimal-versions)
+    #
+    # NOTE: This does not benefit from the 'target' folder cached by a 'cargo
+    # check --all-features --all-targets' execution.  Due to the minimal
+    # dependency set, it still runs fairly quickly.
+    # The empty feature set (as it is done in domain) is not allowed in dnst.
+    - name: Check default feature set
+      run: cargo check --all-targets
+
+    - name: Check openssl feature
+      run: cargo check --all-targets --no-default-features -F openssl
+
+    - name: Check ring feature
+      run: cargo check --all-targets --no-default-features -F ring
+
+  # Check Minimal Versions
+  # ----------------------
+  #
+  # Ensure that 'dnst' compiles with the oldest compatible versions of all
+  # packages, even those 'dnst' depends upon indirectly.
+  check-minimal-versions:
+    name: Check minimal versions
+    runs-on: ubuntu-latest
+    needs: determine-msrv
     env:
       RUSTFLAGS: "-D warnings"
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust nightly
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ needs.determine-msrv.outputs.msrv }},nightly
+        cache: false
+
+    - name: Install OpenSSL
+      run: sudo apt-get install -y libssl-dev
+
+    # TODO: Cache minimal-version dependencies?
+
+    # Lock all dependencies to their minimal versions.
+    - name: Lock dependencies to minimal versions
+      run: cargo +nightly update -Z minimal-versions
+
+    # Check that 'dnst' compiles.
+    #
+    # NOTE: This does not benefit from the 'target' folder cached by a 'cargo
+    # check --all-features --all-targets' execution.  It may be worthwhile to
+    # cache this 'target' folder separately (TODO).
+    - name: Check
+      run: cargo check --all-targets --all-features --locked
+
+  # Clippy
+  # ------
+  #
+  # We run Clippy separately, and only on nightly Rust because it offers a
+  # superset of the lints.
+  #
+  # 'cargo clippy' and 'cargo build' can share some state for fast execution,
+  # but it's faster to execute them in parallel than to establish an ordering
+  # between them.
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust nightly
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: nightly
+        components: clippy
+        cache: false
+
+    # Restore a cache of dependencies and 'target'.
+    - name: Restore from cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+
+    # Do the actually Clippy run.
+    - name: Check Clippy
+      run: cargo +nightly clippy --all-targets --all-features
+
+  # Test
+  # ----
+  #
+  # Ensure that 'dnst' compiles and its test suite passes, on a large number
+  # of operating systems and Rust versions.
+  test:
+    name: Test
+    needs: determine-msrv
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        rust: ["${{ needs.determine-msrv.outputs.msrv }}", stable, beta, nightly]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: "-D warnings"
+      DNST_FEATURES: "--all-features"
       # We use 'vcpkg' to install OpenSSL on Windows.
       VCPKG_ROOT: "${{ github.workspace }}\\vcpkg"
       VCPKGRS_TRIPLET: x64-windows-release
       # Ensure that OpenSSL is dynamically linked.
       VCPKGRS_DYNAMIC: 1
     steps:
+
+    # Load the repository.
     - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v2
-      with:
-        rust-version: ${{ matrix.rust }}
-    - if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y libssl-dev
-    - if: matrix.os == 'windows-latest'
+      uses: actions/checkout@v4
+
+    # Prepare the environment on Windows
+    - name: Prepare Windows environment
+      if: matrix.os == 'windows-latest'
+      # shell: bash
+      # run: |
+      #   # Cargo doesn't support enabling all but one feature, so determine the
+      #   # complete feature list and filter out 'openssl'.
+      #   features=`cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|select(.name == "dnst")|.features|keys|map(select(.!="openssl"))|join(",")'`
+      #   # Overwrite the 'DNST_FEATURES' environment variable.
+      #   echo "DNST_FEATURES=--features=$features" >> "$GITHUB_ENV"
+      #   # See <https://github.com/actions/runner-images/issues/12432>
+      #   echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> "$GITHUB_ENV"
       id: vcpkg
       uses: johnwason/vcpkg-action@v6
       with:
@@ -34,50 +285,158 @@ jobs:
         triplet: ${{ env.VCPKGRS_TRIPLET }}
         token: ${{ github.token }}
         github-binarycache: true
-    - if: matrix.rust == 'stable'
-      run: rustup component add clippy
-    - if: matrix.rust == 'stable'
-      run: cargo clippy --all-features --all-targets -- -D warnings
-    - if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
-      run: cargo fmt --all -- --check
-    - run: cargo check --no-default-features -F ring --all-targets
-    - run: cargo check --no-default-features -F openssl --all-targets
-    - run: cargo test --all-features
 
-  minimal-versions:
-    name: Check minimal versions
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v2
-      with:
-        rust-version: "1.79.0"
     - name: Install OpenSSL
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install -y libssl-dev
-    - name: Install nightly Rust
-      run: rustup install nightly
-    - name: Check with minimal-versions
-      run: |
-        cargo +nightly update -Z minimal-versions
-        cargo check --all-features --all-targets --locked
 
+    # Set up the Rust toolchain.
+    - name: Set up Rust ${{ matrix.rust }}
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        cache: false
+
+    # Restore a cache of dependencies and 'target'.
+    - name: Restore from cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+    
+    # Build and run the test suite.
+    - name: Test
+      run: cargo test --all-targets $DNST_FEATURES
+
+  # Additional (ignored) Tests
+  # --------------------------
+  #
+  # Ensure that the extended test suit passes.
+  # (only on ubuntu-latest and rust stable)
   extra-tests:
     name: Extra tests
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+      DNST_FEATURES: "--all-features"
     steps:
+
+    # Load the repository.
     - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v2
-    - name: Install supporting tools/libraries
-      run: |
-        # The tests compare their output to that of LDNS tools, so we need to
-        # install them. Some tests work with DNSSEC keys for which the OpenSSL
-        # library must be compiled against which requires C build programs and
-        # pkg-config. Install everything we need.
-        sudo apt-get update
-        sudo apt-get install -y build-essential ldnsutils libssl-dev pkg-config
-    - name: Run tests that are normally ignored
-      run: cargo test --all-features --all-targets -- --ignored
+      uses: actions/checkout@v4
+
+    - name: Install supporting tools and libraries
+      # The tests compare their output to that of LDNS tools, so we need to
+      # install them. Some tests work with DNSSEC keys for which the OpenSSL
+      # library must be compiled against which requires C build programs and
+      # pkg-config. Install everything we need.
+      run: sudo apt-get install -y build-essential ldnsutils libssl-dev pkg-config
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust stable
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        cache: false
+
+    # Restore a cache of dependencies and 'target'.
+    - name: Restore from cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+    
+    # Build and run the test suite.
+    - name: Test ignored
+      run: cargo test --all-targets $DNST_FEATURES -- --ignored
+
+  # Build Cache
+  # -----------
+  #
+  # Prepare a cache for checking and building 'dnst', on 'main'.
+  cache:
+    name: Cache
+    needs: determine-msrv
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        rust: ["${{ needs.determine-msrv.outputs.msrv }}", stable, beta, nightly]
+    runs-on: ${{ matrix.os }}
+    if: github.ref == 'refs/heads/main'
+    env:
+      RUSTFLAGS: "-D warnings"
+      DNST_FEATURES: "--all-features"
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Prepare the environment on Windows
+    - name: Prepare Windows environment
+      if: matrix.os == 'windows-latest'
+      # shell: bash
+      # run: |
+      #   # Cargo doesn't support enabling all but one feature, so determine the
+      #   # complete feature list and filter out 'openssl'.
+      #   features=`cargo metadata --no-deps --format-version 1 | jq -r '.packages[]|select(.name == "dnst")|.features|keys|map(select(.!="openssl"))|join(",")'`
+      #   # Overwrite the 'DNST_FEATURES' environment variable.
+      #   echo "DNST_FEATURES=--features=$features" >> "$GITHUB_ENV"
+      #   # See <https://github.com/actions/runner-images/issues/12432>
+      #   mkdir -p .cargo
+      #   printf '[target.x86_64-pc-windows-msvc]\nlinker = "rust-lld"\n' >> .cargo/config.toml
+      id: vcpkg
+      uses: johnwason/vcpkg-action@v6
+      with:
+        pkgs: openssl
+        triplet: ${{ env.VCPKGRS_TRIPLET }}
+        token: ${{ github.token }}
+        github-binarycache: true
+
+    - name: Install OpenSSL
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install -y libssl-dev
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust ${{ matrix.rust }}
+      id: setup-rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        cache: false
+
+    # Restore a cache of dependencies and 'target'.
+    - name: Restore from cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+
+    # Build all of 'dnst'.
+    - name: Build
+      run: cargo build --all-targets $DNST_FEATURES
+
+    # Save to the cache.
+    - name: Save to the cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.cargo
+          target/
+        # Cache by OS and Rust version.
+        key: ${{ runner.os }}-${{ steps.setup-rust.outputs.cachekey }}
+
+# TODO: Use 'cargo-semver-checks' on releases.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@
 # used by others successfully.  It verifies certain aspects of the codebase,
 # such as the formatting and feature flag combinations, and runs the full test
 # suite.  It runs on Ubuntu, Mac OS, and Windows.
+#
+# Based on https://github.com/NLnetLabs/domain/blob/main/.github/workflows/ci.yml
 
 name: CI
 


### PR DESCRIPTION
I noticed that the CI workflow jobs are all run twice when creating PRs, once on push and once on creating the pull_request. Additionally this re-builds all of the code every time. 
To fix that I copied and adapted the CI config from domain and integrated the existing steps into that.