### PR TITLE
Use consistent `signzone` "OUTPUT FORMATTING" help heading styling.

### DIFF
--- a/src/commands/signzone.rs
+++ b/src/commands/signzone.rs
@@ -99,7 +99,7 @@ pub struct SignZone {
     ///
     /// Using this flag enables -O and -R automatically.
     #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
+        help_heading = Some("Output Formatting"),
         short = 'b',
         default_value_t = false
     )]
@@ -252,7 +252,7 @@ pub struct SignZone {
     ///
     /// Requires -n.
     #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
+        help_heading = Some("Output Formatting"),
         short = 'L',
         default_value_t = false,
         requires = "nsec3"
@@ -263,7 +263,7 @@ pub struct SignZone {
     ///
     /// Enabled automatically by -b.
     #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
+        help_heading = Some("Output Formatting"),
         short = 'O',
         default_value_t = false,
         default_value_if("extra_comments", "true", Some("true")),
@@ -275,7 +275,7 @@ pub struct SignZone {
     ///
     /// Enabled automatically by -b.
     #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
+        help_heading = Some("Output Formatting"),
         short = 'R',
         default_value_t = false,
         default_value_if("extra_comments", "true", Some("true")),
@@ -286,7 +286,7 @@ pub struct SignZone {
     ///
     /// Cannot be used with -Z or -H.
     #[arg(
-        help_heading = Some("OUTPUT FORMATTING"),
+        help_heading = Some("Output Formatting"),
         short = 'T',
         default_value_t = false,
         conflicts_with_all = ["allow_zonemd_without_signing", "hash_only"],


### PR DESCRIPTION
Before:
```
$ cargo run -q -- signzone /etc/nsd/zones/example.com -h
Sign the zone with the given key(s)

Usage: dnst signzone [OPTIONS] -o <domain> <zonefile> [key]...

Arguments:
[snip]

Options:
[snip]

OUTPUT FORMATTING:
[snip]

NSEC3 (when using '-n'):
[snip]
```

After:
```
$ cargo run -q -- signzone /etc/nsd/zones/example.com -h
Sign the zone with the given key(s)

Usage: dnst signzone [OPTIONS] -o <domain> <zonefile> [key]...

Arguments:
[snip]

Options:
[snip]

Output Formatting:
[snip]

NSEC3 (when using '-n'):
[snip]
```
