### PR TITLE
Enable the Clap `wrap_help` feature to wrap help text more neatly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ static-openssl = ["openssl/vendored"]
 [dependencies]
 bytes = "1.8.0"
 chrono = "0.4.38"
-clap = { version = "4.3.4", features = ["cargo", "derive"] }
+clap = { version = "4.3.4", features = ["cargo", "derive", "wrap_help"] }
 # Until a release of domain is made that includes the features we need, pin
 # to a specific commit of the domain main branch to ensure that the dnst main
 # branch does not get broken if domain main is not stable.


### PR DESCRIPTION
Before:
<img width="1321" height="1362" alt="Screenshot From 2025-08-18 17-04-51" src="https://github.com/user-attachments/assets/02e233e0-d557-4e27-923b-a03543e933e2" />

After:
<img width="1321" height="1362" alt="Screenshot From 2025-08-18 17-07-41" src="https://github.com/user-attachments/assets/3986aff3-09f4-4295-af98-834beff339f8" />

These screenshots show a fairly minor example of the improvement, the degree of benefit increases with longer help text lines.