### PR TITLE
Reimplement `dnst update` with better UI

### DIFF
--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -75,8 +75,8 @@ Options:
 .. option:: --rrset-exists <DOMAIN_NAME_AND_TYPE>
 
       Require that at least one RR with the given NAME and TYPE exists.
-      (Optionally) provide this option multiple times, with format
-      ``<DOMAIN_NAME> <TYPE>`` each, to build up a list of RRs.
+      This option can be provided multiple times, with format ``<DOMAIN_NAME>
+      <TYPE>`` each, to build up a list of RRs.
 
       If the domain name is relative, it will be relative to the zone's apex.
 
@@ -85,9 +85,9 @@ Options:
 .. option:: --rrset-exists-exact <RESOURCE_RECORD>
 
       Require that an RRset exists and contains exactly the RRs with the given
-      NAME, TYPE, and RDATA. (Optionally) provide this option multiple times,
-      each with one RR in zonefile format, to build up one or more RRsets that
-      is required to exist. CLASS and TTL can be omitted.
+      NAME, TYPE, and RDATA. This option can be provided multiple times, each
+      with one RR in zonefile format, to build up one or more RRsets that is
+      required to exist. CLASS and TTL can be omitted.
 
       If the domain name is relative, it will be relative to the zone's apex.
 
@@ -95,8 +95,8 @@ Options:
 
 .. option:: --rrset-non-existent <DOMAIN_NAME_AND_TYPE>
 
-      RRset does not exist. (Optionally) provide this option multiple times,
-      with format ``<DOMAIN_NAME> <TYPE>`` each, to build up a list of RRs that
+      RRset does not exist. This option can be provided multiple times, with
+      format ``<DOMAIN_NAME> <TYPE>`` each, to build up a list of RRs that
       specify that no RRs with a specified NAME and TYPE can exist.
 
       If the domain name is relative, it will be relative to the zone's apex.
@@ -105,9 +105,9 @@ Options:
 
 .. option:: --name-in-use <DOMAIN_NAME>
 
-      Name is in use. (Optionally) provide this option multiple times, with
-      format ``<DOMAIN_NAME>`` each, to collect a list of NAMEs that must own
-      at least one RR.
+      Name is in use. This option can be provided multiple times, with format
+      ``<DOMAIN_NAME>`` each, to collect a list of NAMEs that must own at least
+      one RR.
 
       Note that this prerequisite is NOT satisfied by empty nonterminals.
 
@@ -117,7 +117,7 @@ Options:
 
 .. option:: --name-not-in-use <DOMAIN_NAME>
 
-      Name is not in use. (Optionally) provide this option multiple times, with
+      Name is not in use. This option can be provided multiple times, with
       format ``<DOMAIN_NAME>`` each, to collect a list of NAMEs that must NOT
       own any RRs.
 

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -53,17 +53,16 @@ Options:
 
       TTL in seconds or with unit suffix (s, m, h, d, w, M, y).
 
+      Is only used by the :subcmd:`add` command and is otherwise ignored.
+
       Defaults to 3600.
 
 .. option:: -s, --server <IP>
 
-      Name server to send the update to (can be provided multiple times).
+      The name server to send the update to.
 
-      The UPDATE message will be sent to each server in a row until a name server replies with 
-      TODO: 
-
-      By default, the list of name servers to try one-by-one is fetched from
-      the zone's NS RRset.
+      By default, the update will be sent to the list of name servers fetched
+      from the zone's NS RRset as per RFC 2136.
 
 .. option:: -z, --zone <ZONE>
 

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -74,12 +74,9 @@ Options:
 
 .. option:: --rrset-exists <DOMAIN_NAME_AND_TYPE>
 
-      RRset exists (value independent). (Optionally) provide this option
-      multiple times, with format ``<DOMAIN_NAME> <TYPE>`` each, to build up
-      a list of RR(set)s.
-
-      This specifies the prerequisite that at least one RR with a specified
-      NAME and TYPE must exist.
+      Require that at least one RR with the given NAME and TYPE exists.
+      (Optionally) provide this option multiple times, with format
+      ``<DOMAIN_NAME> <TYPE>`` each, to build up a list of RRs.
 
       If the domain name is relative, it will be relative to the zone's apex.
 
@@ -87,13 +84,10 @@ Options:
 
 .. option:: --rrset-exists-exact <RESOURCE_RECORD>
 
-      RRset exists (value dependent). (Optionally) provide this option multiple
-      times, each with one RR in zonefile format, to build up one or more
-      RRsets that is required to exist. CLASS and TTL can be omitted.
-
-      This specifies the prerequisite that a set of RRs with a specified NAME
-      and TYPE exists and has the same members with the same RDATAs as the
-      RRset specified.
+      Require that an RRset exists and contains exactly the RRs with the given
+      NAME, TYPE, and RDATA. (Optionally) provide this option multiple times,
+      each with one RR in zonefile format, to build up one or more RRsets that
+      is required to exist. CLASS and TTL can be omitted.
 
       If the domain name is relative, it will be relative to the zone's apex.
 

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -4,50 +4,158 @@ dnst update
 Synopsis
 --------
 
-:program:`dnst update` ``<DOMAIN NAME>`` ``[ZONE]`` ``<IP>``
-``[<TSIG KEY NAME> <TSIG ALGORITHM> <TSIG KEY DATA>]``
+:program:`dnst update` ``[OPTIONS]`` ``<DOMAIN NAME>`` ``<COMMAND>``
+
+:program:`dnst update` ``[OPTIONS]`` ``<DOMAIN NAME>`` :subcmd:`add` ``<RRTYPE>`` ``[RDATA]...``
+
+:program:`dnst update` ``[OPTIONS]`` ``<DOMAIN NAME>`` :subcmd:`delete` ``<RRTYPE>`` ``[RDATA]...``
+
+:program:`dnst update` ``[OPTIONS]`` ``<DOMAIN NAME>`` :subcmd:`clear` ``<RRTYPE>``
 
 Description
 -----------
 
 **dnst update** sends an RFC 2136 Dynamic Update message to the name servers
-for a zone to update an IP address (or delete all existing IP addresses) for a
-domain name.
+for a zone to add, update, or delete arbitrary Resource Records for a domain
+name.
 
 The message to be sent can be optionally authenticated using a given TSIG key.
+
+**dnst update [...] add** adds the given RRs to the domain.
+
+**dnst update [...] delete** deletes the given RRs from the domain. It can be
+used to delete individual RRs or a whole RRset.
+
+**dnst update [...] clear** clears (deletes) all RRs of any type from the
+domain name.
 
 Arguments
 ---------
 
 .. option:: <DOMAIN NAME>
 
-      The domain name to update the IP address of.
+      The domain name of the RR(s) to update.
 
-.. option:: <ZONE>
+.. option:: <COMMAND>
 
-      The zone to send the update to (if omitted, derived from SOA record).
-
-.. option:: <IP>
-
-      The IP address to update the domain with (``none`` to remove any
-      existing IP addresses)
-
-.. option:: <TSIG KEY NAME>
-
-      TSIG key name.
-
-.. option:: <TSIG ALGORITHM>
-
-      TSIG algorithm (e.g. "hmac-sha256").
-
-.. option:: <TSIG KEY DATA>
-
-      Base64 encoded TSIG key data.
+      Which action to take: add, delete, or clear.
 
 Options:
 --------
 
+.. option:: -c, --class <CLASS>
+
+      Class
+
+      Defaults to IN.
+
+.. option:: -t, --ttl <TTL>
+
+      TTL in seconds or with unit suffix (s, m, h, d, w, M, y).
+
+      Defaults to 3600.
+
+.. option:: -s, --server <IP>
+
+      Name server to send the update to (can be provided multiple times).
+
+      The UPDATE message will be sent to each server in a row until a name server replies with 
+      TODO: 
+
+      By default, the list of name servers to try one-by-one is fetched from
+      the zone's NS RRset.
+
+.. option:: -z, --zone <ZONE>
+
+      The zone the domain name belongs to (to skip a SOA query)
+
+.. option:: -y, --tsig <NAME:KEY[:ALGO]>
+
+      TSIG credentials for the UPDATE packet
+
+.. option:: --rrset-exists <DOMAIN_NAME_AND_TYPE>
+
+      RRset exists (value independent). (Optionally) provide this option
+      multiple times, with format ``<DOMAIN_NAME> <TYPE>`` each, to build up
+      a list of RR(set)s.
+
+      This specifies the prerequisite that at least one RR with a specified
+      NAME and TYPE must exist.
+
+      If the domain name is relative, it will be relative to the zone's apex.
+
+      [aliases: --rrset]
+
+.. option:: --rrset-exists-exact <RESOURCE_RECORD>
+
+      RRset exists (value dependent). (Optionally) provide this option multiple
+      times, each with one RR in zonefile format, to build up one or more
+      RRsets that is required to exist. CLASS and TTL can be omitted.
+
+      This specifies the prerequisite that a set of RRs with a specified NAME
+      and TYPE exists and has the same members with the same RDATAs as the
+      RRset specified.
+
+      If the domain name is relative, it will be relative to the zone's apex.
+
+      [aliases: --rrset-exact]
+
+.. option:: --rrset-non-existent <DOMAIN_NAME_AND_TYPE>
+
+      RRset does not exist. (Optionally) provide this option multiple times,
+      with format ``<DOMAIN_NAME> <TYPE>`` each, to build up a list of RRs that
+      specify that no RRs with a specified NAME and TYPE can exist.
+
+      If the domain name is relative, it will be relative to the zone's apex.
+
+      [aliases: --rrset-empty]
+
+.. option:: --name-in-use <DOMAIN_NAME>
+
+      Name is in use. (Optionally) provide this option multiple times, with
+      format ``<DOMAIN_NAME>`` each, to collect a list of NAMEs that must own
+      at least one RR.
+
+      Note that this prerequisite is NOT satisfied by empty nonterminals.
+
+      If the domain name is relative, it will be relative to the zone's apex.
+
+      [aliases: --name-used]
+
+.. option:: --name-not-in-use <DOMAIN_NAME>
+
+      Name is not in use. (Optionally) provide this option multiple times, with
+      format ``<DOMAIN_NAME>`` each, to collect a list of NAMEs that must NOT
+      own any RRs.
+
+      Note that this prerequisite IS satisfied by empty nonterminals.
+
+      If the domain name is relative, it will be relative to the zone's apex.
+
+      [aliases: --name-unused]
+
 .. option:: -h, --help
 
       Print the help text (short summary with ``-h``, long help with
-      ``--help``).
+      ``--help``). Can also be used on the individual sub commands.
+
+Arguments for :subcmd:`add` and :subcmd:`delete`
+------------------------------------------------------
+
+.. option:: <RRTYPE>
+
+      The RR type to add or delete.
+
+.. option:: [RDATA]...
+
+      One or more RDATA arguments (fully optional for :subcmd:`delete`).
+
+      Each argument corresponds to a single RR's RDATA, so beware of (shell and
+      DNS) quoting rules.
+
+      Each RDATA argument will be parsed as if it was read from a zone file.
+
+      | Examples:
+      | :code:`dnst update some.example.com add AAAA ::1 2001:db8::`
+      | :code:`dnst update some.example.com add TXT '"Spacious String" "Another
+          string for the same TXT record"' '"This is another TXT RR"'`

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -51,7 +51,7 @@ Options:
 
 .. option:: -t, --ttl <TTL>
 
-      TTL in seconds or with unit suffix (s, m, h, d, w, M, y).
+      TTL in seconds or with unit suffix (s, m, h, d).
 
       Is only used by the :subcmd:`add` command and is otherwise ignored.
 

--- a/doc/manual/source/man/dnst-update.rst
+++ b/doc/manual/source/man/dnst-update.rst
@@ -141,7 +141,8 @@ Arguments for :subcmd:`add` and :subcmd:`delete`
 
 .. option:: [RDATA]...
 
-      One or more RDATA arguments (fully optional for :subcmd:`delete`).
+      One or more RDATA arguments for :subcmd:`add`, and zero or more for
+      :subcmd:`delete`.
 
       Each argument corresponds to a single RR's RDATA, so beware of (shell and
       DNS) quoting rules.

--- a/src/commands/key2ds.rs
+++ b/src/commands/key2ds.rs
@@ -144,7 +144,6 @@ impl Key2ds {
         })?;
         let zonefile = domain::zonefile::inplace::Zonefile::load(&mut file).unwrap();
         for entry in zonefile {
-            dbg!(&entry);
             let entry = entry.map_err(|e| {
                 format!(
                     "Error while reading public key from file \"{}\": {e}",

--- a/src/commands/key2ds.rs
+++ b/src/commands/key2ds.rs
@@ -144,6 +144,7 @@ impl Key2ds {
         })?;
         let zonefile = domain::zonefile::inplace::Zonefile::load(&mut file).unwrap();
         for entry in zonefile {
+            dbg!(&entry);
             let entry = entry.map_err(|e| {
                 format!(
                     "Error while reading public key from file \"{}\": {e}",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -74,6 +74,13 @@ pub enum Command {
     #[command(name = "update")]
     Update(self::update::Update),
 
+    /// Send an UPDATE packet ldns compatibility variant
+    ///
+    /// This variant is not a dnst command and only used to provide
+    /// a separate implementation from the dnst update command.
+    #[command(skip)]
+    LdnsUpdate(self::update::LdnsUpdate),
+
     /// Show the manual pages
     Help(self::help::Help),
 
@@ -94,6 +101,7 @@ impl Command {
             Self::Notify(notify) => notify.execute(env),
             Self::SignZone(signzone) => signzone.execute(env),
             Self::Update(update) => update.execute(env),
+            Self::LdnsUpdate(ldnsupdate) => ldnsupdate.execute(env),
             Self::Help(help) => help.execute(),
             Self::Report(s) => {
                 writeln!(env.stdout(), "{s}");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1271,7 +1271,7 @@ mod test {
                     algorithm: Algorithm::Sha256,
                 }),
                 ttl: Ttl::from_secs(60),
-                nameservers: vec![[127, 0, 0, 9].into()],
+                nameservers: Some([127, 0, 0, 9].into()),
                 action: UpdateAction::Add {
                     rtype: Rtype::TXT,
                     rdata: vec!["Hallo".into()]

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -411,7 +411,9 @@ impl Update {
         match zonefile.next_entry() {
             Ok(Some(Entry::Record(record))) => Ok(record.data().clone().flatten_into()),
             Ok(_) => unreachable!("We always create a record"),
-            Err(e) => Err(format!("Failed to parse rdata for {rtype} {rdata} -- Error: {e}").into()),
+            Err(e) => {
+                Err(format!("Failed to parse rdata for {rtype} {rdata} -- Error: {e}").into())
+            }
         }
     }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -36,31 +36,8 @@ use crate::Args;
 
 use super::{parse_os, parse_os_with, Command, LdnsCommand};
 
-// TODO: add .context() to errors?
-
-// UI:
-// Synopsis:
-// - `dnst update [options] add <domain name> <RRTYPE> <RRs>...`
-// - `dnst update [options] delete <domain name> <RRTYPE> [<RRs>...]`
-// - `dnst update [options] clear <domain name>` (distinction to avoid accidental deletion of whole domain names)
-
-// Examples:
-// - `dnst update add <domain name> AAAA "::1" "::2"` - Add multiple AAAA records
-// - `dnst update add <domain name> TXT "challenge"` - Add multiple TXT records
-// - `dnst update delete <domain name> AAAA ::1 ::2` - Delete exact AAAA RRs on domain name (`::1` and `::2` in this case)
-// - `dnst update delete <domain name> AAAA` - Delete all AAAA RRs on domain name
-// - `dnst update clear <domain name>` - Delete all RRSETs on domain name, aka delete the whole domain name
-
-// type SomeRecord = Record<NameVecU8, ZoneRecordData<Vec<u8>, NameVecU8>>;
-// type SomeRecord = Record<Name<Vec<u8>>, ZoneRecordData<Vec<u8>, Name<Vec<u8>>>>;
 type ParsedRecord = Record<Name<Vec<u8>>, ZoneRecordData<Vec<u8>, Name<Vec<u8>>>>;
-// type SomeRecord = ScannedRecord;
 type NameTypeTuple = (Name<Vec<u8>>, Rtype);
-
-// pub type ScannedDname = Chain<RelativeName<Bytes>, Name<Bytes>>;
-// pub type ScannedRecordData = ZoneRecordData<Bytes, ScannedDname>;
-// pub type ScannedRecord = Record<ScannedDname, ScannedRecordData>;
-// pub type ScannedString = Str<Bytes>;
 
 //------------ Update --------------------------------------------------------
 
@@ -101,8 +78,7 @@ pub struct Update {
     /// This specifies the prerequisite that at least one RR with a specified
     /// NAME and TYPE must exist.
     ///
-    /// Note that, if the domain name is relative, it will be relative to the
-    /// zone's apex.
+    /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
         long = "rrset-exists",
         visible_alias = "rrset",
@@ -118,6 +94,8 @@ pub struct Update {
     /// This specifies the prerequisite that a set of RRs with a specified
     /// NAME and TYPE exists and has the same members with the same RDATAs as
     /// the RRset specified.
+    ///
+    /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
         long = "rrset-exists-exact",
         visible_alias = "rrset-exact",
@@ -128,6 +106,8 @@ pub struct Update {
     /// RRset does not exist. (Optionally) provide this option multiple times,
     /// with format "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs
     /// that specify that no RRs with a specified NAME and TYPE can exist.
+    ///
+    /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
         long = "rrset-non-existent",
         visible_alias = "rrset-empty",
@@ -140,6 +120,8 @@ pub struct Update {
     /// own at least one RR.
     ///
     /// Note that this prerequisite is NOT satisfied by empty nonterminals.
+    ///
+    /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
         long = "name-in-use",
         visible_alias = "name-used",
@@ -152,6 +134,8 @@ pub struct Update {
     /// NOT own any RRs.
     ///
     /// Note that this prerequisite IS satisfied by empty nonterminals.
+    ///
+    /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
         long = "name-not-in-use",
         visible_alias = "name-unused",

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -73,12 +73,9 @@ pub struct Update {
     #[arg(short = 'y', long = "tsig", value_name = "NAME:KEY[:ALGO]")]
     tsig: Option<TSigInfo>,
 
-    /// RRset exists (value independent). (Optionally) provide this option
-    /// multiple times, with format "<DOMAIN_NAME> <TYPE>" each, to
-    /// build up a list of RR(set)s.
-    ///
-    /// This specifies the prerequisite that at least one RR with a specified
-    /// NAME and TYPE must exist.
+    /// Require that at least one RR with the given NAME and TYPE exists.
+    /// (Optionally) provide this option multiple times, with format
+    /// "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs.
     ///
     /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
@@ -88,14 +85,10 @@ pub struct Update {
     )]
     rrset_exists: Option<Vec<String>>,
 
-    /// RRset exists (value dependent). (Optionally) provide this option
-    /// multiple times, each with one RR in zonefile format, to build up one
-    /// or more RRsets that is required to exist. CLASS and TTL can be
-    /// omitted.
-    ///
-    /// This specifies the prerequisite that a set of RRs with a specified
-    /// NAME and TYPE exists and has the same members with the same RDATAs as
-    /// the RRset specified.
+    /// Require that an RRset exists and contains exactly the RRs with the given
+    /// NAME, TYPE, and RDATA. (Optionally) provide this option multiple times,
+    /// each with one RR in zonefile format, to build up one or more RRsets that
+    /// is required to exist. CLASS and TTL can be omitted.
     ///
     /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -74,8 +74,8 @@ pub struct Update {
     tsig: Option<TSigInfo>,
 
     /// Require that at least one RR with the given NAME and TYPE exists.
-    /// (Optionally) provide this option multiple times, with format
-    /// "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs.
+    /// This option can be provided multiple times, with format "<DOMAIN_NAME>
+    /// <TYPE>" each, to build up a list of RRs.
     ///
     /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
@@ -86,9 +86,9 @@ pub struct Update {
     rrset_exists: Option<Vec<String>>,
 
     /// Require that an RRset exists and contains exactly the RRs with the given
-    /// NAME, TYPE, and RDATA. (Optionally) provide this option multiple times,
-    /// each with one RR in zonefile format, to build up one or more RRsets that
-    /// is required to exist. CLASS and TTL can be omitted.
+    /// NAME, TYPE, and RDATA. This option can be provided multiple times, each
+    /// with one RR in zonefile format, to build up one or more RRsets that is
+    /// required to exist. CLASS and TTL can be omitted.
     ///
     /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
@@ -98,9 +98,9 @@ pub struct Update {
     )]
     rrset_exists_exact: Option<Vec<String>>,
 
-    /// RRset does not exist. (Optionally) provide this option multiple times,
-    /// with format "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs
-    /// that specify that no RRs with a specified NAME and TYPE can exist.
+    /// RRset does not exist. This option can be provided multiple times, with
+    /// format "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs that
+    /// specify that no RRs with a specified NAME and TYPE can exist.
     ///
     /// If the domain name is relative, it will be relative to the zone's apex.
     #[arg(
@@ -110,9 +110,9 @@ pub struct Update {
     )]
     rrset_non_existent: Option<Vec<String>>,
 
-    /// Name is in use. (Optionally) provide this option multiple times,
-    /// with format "<DOMAIN_NAME>" each, to collect a list of NAMEs that must
-    /// own at least one RR.
+    /// Name is in use. This option can be provided multiple times, with format
+    /// "<DOMAIN_NAME>" each, to collect a list of NAMEs that must own at least
+    /// one RR.
     ///
     /// Note that this prerequisite is NOT satisfied by empty nonterminals.
     ///
@@ -124,9 +124,9 @@ pub struct Update {
     )]
     name_in_use: Option<Vec<String>>,
 
-    /// Name is not in use. (Optionally) provide this option multiple times,
-    /// with format "<DOMAIN_NAME>" each, to collect a list of NAMEs that must
-    /// NOT own any RRs.
+    /// Name is not in use. This option can be provided multiple times, with
+    /// format "<DOMAIN_NAME>" each, to collect a list of NAMEs that must NOT
+    /// own any RRs.
     ///
     /// Note that this prerequisite IS satisfied by empty nonterminals.
     ///

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -618,6 +618,8 @@ impl Update {
             msg: &Message<Vec<u8>>,
             tsig_key: &Option<Key>,
         ) -> Result<Message<bytes::Bytes>, domain::net::client::request::Error> {
+            // TODO: Use TCP directly or at least implement TCP fallback
+
             // // Using TCP directly to skip check whether the request fits
             // // in a UDP packet.
             // let tcp_connect = TcpConnect::new(socket);

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -355,35 +355,30 @@ impl Update {
                             self.ttl,
                             rdata,
                         ))
-                        .map_err(|e| -> Error {
-                            format!("Failed to add RR to UPDATE message: {e}").into()
-                        })?
+                        .map_err(|e| format!("Failed to add RR to UPDATE message: {e}"))?
                 }
             }
             UpdateAction::Delete { rtype, ref rdata } => {
                 if rdata.is_empty() {
                     update_section
                         .push(Self::create_rrset_deletion(self.domain.clone(), rtype))
-                        .map_err(|e| -> Error {
-                            format!("Failed to add RRset deletion RR to UPDATE message: {e}").into()
+                        .map_err(|e| {
+                            format!("Failed to add RRset deletion RR to UPDATE message: {e}")
                         })?
                 } else {
                     for r in rdata {
                         let rdata = Self::parse_rdata(rtype, r)?;
                         update_section
                             .push(Self::create_rr_deletion(self.domain.clone(), rdata))
-                            .map_err(|e| -> Error {
+                            .map_err(|e| {
                                 format!("Failed to add RR deletion RR to UPDATE message: {e}")
-                                    .into()
                             })?
                     }
                 }
             }
             UpdateAction::Clear => update_section
                 .push(Self::create_all_rrset_deletion(self.domain.clone()))
-                .map_err(|e| -> Error {
-                    format!("Failed to add RRset deletion RR to UPDATE message: {e}").into()
-                })?,
+                .map_err(|e| format!("Failed to add RRset deletion RR to UPDATE message: {e}"))?,
         }
 
         // Providing additional data is not yet implemented

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -260,15 +260,14 @@ impl Update {
     ) -> Result<Vec<Name<Vec<u8>>>, Error> {
         let mut names = Vec::new();
         for name in args {
-            let uncertain = UncertainName::from_str(name)
+            let uncertain = UncertainName::<Vec<u8>>::from_str(name)
                 .map_err(|e| -> Error { format!("Invalid domain name '{name}': {e}").into() })?;
-            let name = match uncertain.as_absolute() {
-                Some(name) => name.clone(),
-                None => uncertain
-                    .chain(origin)
-                    .expect("we just checked that its not absolute")
-                    .to_name(),
-            };
+            let name = uncertain
+                .chain(origin)
+                .map_err(|_| -> Error {
+                    format!("Combining {name}.{origin} is too long for a domain name").into()
+                })?
+                .to_name();
             names.push(name)
         }
         Ok(names)

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -295,17 +295,17 @@ impl Update {
             if let Some(ttl) = arg.strip_suffix('s') {
                 ttl.parse()
             } else if let Some(ttl) = arg.strip_suffix('m') {
-                ttl.parse::<u32>().map(|t| t / 60)
+                ttl.parse::<u32>().map(|t| t * 60)
             } else if let Some(ttl) = arg.strip_suffix('h') {
-                ttl.parse::<u32>().map(|t| t / 3600)
+                ttl.parse::<u32>().map(|t| t * 3600)
             } else if let Some(ttl) = arg.strip_suffix('d') {
-                ttl.parse::<u32>().map(|t| t / 86400)
+                ttl.parse::<u32>().map(|t| t * 86400)
             } else if let Some(ttl) = arg.strip_suffix('w') {
-                ttl.parse::<u32>().map(|t| t / 604800)
+                ttl.parse::<u32>().map(|t| t * 604800)
             } else if let Some(ttl) = arg.strip_suffix('M') {
-                ttl.parse::<u32>().map(|t| t / 2629746) // 30.436875 days
+                ttl.parse::<u32>().map(|t| t * 2629746) // 30.436875 days
             } else if let Some(ttl) = arg.strip_suffix('y') {
-                ttl.parse::<u32>().map(|t| t / 31556952) // 365.2425 days
+                ttl.parse::<u32>().map(|t| t * 31556952) // 365.2425 days
             } else {
                 arg.parse()
             }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -87,7 +87,7 @@ pub struct Update {
     nameservers: Vec<IpAddr>,
 
     /// Zone the domain name belongs to (to skip SOA query)
-    #[arg(short = 'z', long = "ZONE")]
+    #[arg(short = 'z', long = "zone", value_name = "ZONE")]
     zone: Option<Name<Vec<u8>>>,
 
     /// TSIG credentials for the UPDATE packet

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -228,16 +228,15 @@ impl Update {
                 let typ = Rtype::from_str(typ).map_err(|e| -> Error {
                     format!("Invalid resource record type '{typ}': {e}").into()
                 })?;
-                let uncertain = UncertainName::from_str(name).map_err(|e| -> Error {
+                let uncertain = UncertainName::<Vec<u8>>::from_str(name).map_err(|e| -> Error {
                     format!("Invalid domain name '{name}': {e}").into()
                 })?;
-                let name = match uncertain.as_absolute() {
-                    Some(name) => name.clone(),
-                    None => uncertain
-                        .chain(origin)
-                        .expect("we just checked that its not absolute")
-                        .to_name(),
-                };
+                let name = uncertain
+                    .chain(origin)
+                    .map_err(|_| -> Error {
+                        format!("Combining {name}.{origin} is too long for a domain name").into()
+                    })?
+                    .to_name();
                 records.push((name, typ))
             } else {
                 return Err(format!(

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -191,7 +191,9 @@ impl Update {
         // };
 
         // Parse prerequisites before fetching nameservers, in case parsing fails
-        let prerequisites = self.parse_prerequisites(apex.clone().flatten_into())?;
+        let prerequisites = self
+            .parse_prerequisites(apex.clone().flatten_into())
+            .context("parsing the prerequisite arguments")?;
 
         // 1. (Cont.) If not provided, determine zone apex and fetch name servers
         let nsnames = if self.nameservers.is_none() {
@@ -199,7 +201,7 @@ impl Update {
                 // 3. Order nameserver list, listing primary first
                 update_helpers::determine_nsnames(env, &apex, &mname)
                     .await
-                    .context("while fetching the authoritative nameservers for the zone")?,
+                    .context("fetching the authoritative nameservers for the zone")?,
             )
         } else {
             None

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -200,6 +200,7 @@ impl Update {
         // 1. (Cont.) If not provided, determine zone apex and fetch name servers
         let nsnames = if self.nameservers.is_empty() {
             Some(
+                // 3. Order nameserver list, listing primary first
                 UpdateHelpers::determine_nsnames(env, &apex, &mname)
                     .await
                     .context("while fetching the authoritative nameservers for the zone")?,
@@ -208,6 +209,7 @@ impl Update {
             None
         };
 
+        // 4. Create UPDATE and send to first server in list
         // TODO: pass SOA record fetched above to make sure changes to the SOA
         // record by the user adhere to the RFC specifications of e.g. only
         // increasing serial

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -600,12 +600,10 @@ mod test {
         ";
 
         let cmd = FakeCmd::new([
-            "dnst",
-            "update",
+            "ldns-update",
             "foo.test",
-            "none",
-            "--zone",
             "zone.foo.test",
+            "none",
         ])
         .stelline(rpl.as_bytes(), "update.rpl");
 
@@ -617,7 +615,7 @@ mod test {
         );
         assert_eq!(res.stderr, "");
 
-        let cmd = FakeCmd::new(["dnst", "update", "foo.test", "none"])
+        let cmd = FakeCmd::new(["ldns-update", "foo.test", "none"])
             .stelline(rpl.as_bytes(), "update.rpl");
 
         let res = cmd.run();

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -408,10 +408,10 @@ impl Update {
         // parse the rdata
         let rr = format!(". 1 IN {rtype} {rdata}\n");
         zonefile.extend_from_slice(rr.as_bytes());
-        if let Ok(Some(Entry::Record(record))) = zonefile.next_entry() {
-            Ok(record.data().clone().flatten_into())
-        } else {
-            Err(format!("Failed to parse rdata for {rtype}: {rdata}").into())
+        match zonefile.next_entry() {
+            Ok(Some(Entry::Record(record))) => Ok(record.data().clone().flatten_into()),
+            Ok(_) => unreachable!("We always create a record"),
+            Err(e) => Err(format!("Failed to parse rdata for {rtype} {rdata} -- Error: {e}").into()),
         }
     }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -55,7 +55,7 @@ pub struct Update {
     #[arg(short = 'c', long = "class", default_value_t = Class::IN)]
     class: Class,
 
-    /// TTL in seconds or with unit suffix (s, m, h, d, w, M, y).
+    /// TTL in seconds or with unit suffix (s, m, h, d).
     ///
     /// Is only used by the `add` command and ignored otherwise.
     #[arg(short = 't', long = "ttl", value_parser = Update::parse_ttl, default_value = "3600")]
@@ -300,12 +300,6 @@ impl Update {
                 ttl.parse::<u32>().map(|t| t * 3600)
             } else if let Some(ttl) = arg.strip_suffix('d') {
                 ttl.parse::<u32>().map(|t| t * 86400)
-            } else if let Some(ttl) = arg.strip_suffix('w') {
-                ttl.parse::<u32>().map(|t| t * 604800)
-            } else if let Some(ttl) = arg.strip_suffix('M') {
-                ttl.parse::<u32>().map(|t| t * 2629746) // 30.436875 days
-            } else if let Some(ttl) = arg.strip_suffix('y') {
-                ttl.parse::<u32>().map(|t| t * 31556952) // 365.2425 days
             } else {
                 arg.parse()
             }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -381,7 +381,7 @@ impl Update {
                 .map_err(|e| format!("Failed to add RRset deletion RR to UPDATE message: {e}"))?,
         }
 
-        // Providing additional data is not yet implemented
+        // TODO: Providing additional data is not yet implemented
         // let mut additional_section = update_section.additional();
 
         Ok(update_section.finish())

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -647,7 +647,7 @@ impl Update {
                 Box::new(dgram_connection)
             };
 
-            let msg_dig = Update::update_to_dig_fmt(&msg);
+            let msg_dig = Update::update_to_dig_fmt(msg);
             trace!("Sending UPDATE:\n{msg_dig}");
             connection
                 .send_request(RequestMessage::new(msg.clone()).unwrap())
@@ -863,7 +863,7 @@ impl Update {
                     data
                 )),
                 (_, _, _, _) => {
-                    target.push_str(&format!("Adding RR:  "));
+                    target.push_str("Adding RR:  ");
                     target.push_str(&format!(
                         "{}  {}  {}  {}  {}\n",
                         item.owner(),
@@ -955,7 +955,7 @@ impl Update {
         // Should only be one...
         for item in questions {
             let item = item.expect("we created this message, it should be valid");
-            target.push_str(&format!("; {}\n", item));
+            target.push_str(&format!("; {item}\n"));
             class = Some(item.qclass());
         }
 
@@ -994,7 +994,7 @@ impl Update {
             .expect("we created this message, it should be valid")
             .unwrap();
         if counts.arcount() > 0 || (opt.is_none() && counts.arcount() > 0) {
-            target.push_str(&format!("\n;; ADDITIONAL SECTION:\n"));
+            target.push_str("\n;; ADDITIONAL SECTION:\n");
             for item in additional {
                 let item = item.expect("we created this message, it should be valid");
                 if item.rtype() != Rtype::OPT {
@@ -1011,7 +1011,7 @@ impl Update {
             let parsed = item.to_any_record::<AllRecordData<_, _>>();
 
             if parsed.is_err() {
-                target.push_str(&format!("; "));
+                target.push_str("; ");
             }
 
             let data = match parsed {
@@ -1050,7 +1050,7 @@ impl Update {
         let opt = msg.opt(); // We need it further down ...
 
         if let Some(opt) = opt.as_ref() {
-            target.push_str(&format!("\n;; OPT PSEUDOSECTION:\n"));
+            target.push_str("\n;; OPT PSEUDOSECTION:\n");
             target.push_str(&format!(
                 "; EDNS: version {}, flags: {}; udp: {}\n",
                 opt.version(),
@@ -1062,11 +1062,11 @@ impl Update {
 
                 match option {
                     Ok(opt) => match opt {
-                        Nsid(nsid) => target.push_str(&format!("; NSID: {}\n", nsid)),
-                        Dau(dau) => target.push_str(&format!("; DAU: {}\n", dau)),
-                        Dhu(dhu) => target.push_str(&format!("; DHU: {}\n", dhu)),
-                        N3u(n3u) => target.push_str(&format!("; N3U: {}\n", n3u)),
-                        Expire(expire) => target.push_str(&format!("; EXPIRE: {}\n", expire)),
+                        Nsid(nsid) => target.push_str(&format!("; NSID: {nsid}\n")),
+                        Dau(dau) => target.push_str(&format!("; DAU: {dau}\n")),
+                        Dhu(dhu) => target.push_str(&format!("; DHU: {dhu}\n")),
+                        N3u(n3u) => target.push_str(&format!("; N3U: {n3u}\n")),
+                        Expire(expire) => target.push_str(&format!("; EXPIRE: {expire}\n")),
                         TcpKeepalive(opt) => target.push_str(&format!(
                             "; TCP KEEPALIVE: {}\n",
                             opt.timeout().map_or("".to_string(), |t| format!(
@@ -1074,21 +1074,21 @@ impl Update {
                                 Duration::from(t).as_secs_f64()
                             ))
                         )),
-                        Padding(padding) => target.push_str(&format!("; PADDING: {}\n", padding)),
-                        ClientSubnet(opt) => target.push_str(&format!("; CLIENTSUBNET: {}\n", opt)),
-                        Cookie(cookie) => target.push_str(&format!("; COOKIE: {}\n", cookie)),
-                        Chain(chain) => target.push_str(&format!("; CHAIN: {}\n", chain)),
-                        KeyTag(keytag) => target.push_str(&format!("; KEYTAG: {}\n", keytag)),
+                        Padding(padding) => target.push_str(&format!("; PADDING: {padding}\n")),
+                        ClientSubnet(opt) => target.push_str(&format!("; CLIENTSUBNET: {opt}\n")),
+                        Cookie(cookie) => target.push_str(&format!("; COOKIE: {cookie}\n")),
+                        Chain(chain) => target.push_str(&format!("; CHAIN: {chain}\n")),
+                        KeyTag(keytag) => target.push_str(&format!("; KEYTAG: {keytag}\n")),
                         ExtendedError(extendederror) => {
-                            target.push_str(&format!("; EDE: {}\n", extendederror))
+                            target.push_str(&format!("; EDE: {extendederror}\n"))
                         }
                         Other(other) => {
                             target.push_str(&format!("; {}\n", other.code()));
                         }
-                        _ => target.push_str(&format!("Unknown OPT\n")),
+                        _ => target.push_str("Unknown OPT\n"),
                     },
                     Err(err) => {
-                        target.push_str(&format!("; ERROR: bad option: {}.\n", err));
+                        target.push_str(&format!("; ERROR: bad option: {err}.\n"));
                     }
                 }
             }
@@ -1097,10 +1097,10 @@ impl Update {
         // Question
         let questions = msg.question();
         if counts.qdcount() > 0 {
-            target.push_str(&format!(";; QUESTION SECTION:\n"));
+            target.push_str(";; QUESTION SECTION:\n");
             for item in questions {
                 let item = item.expect("we created this message, it should be valid");
-                target.push_str(&format!(";{}\n", item));
+                target.push_str(&format!(";{item}\n"));
             }
         }
 
@@ -1109,7 +1109,7 @@ impl Update {
             .answer()
             .expect("we created this message, it should be valid");
         if counts.ancount() > 0 {
-            target.push_str(&format!("\n;; ANSWER SECTION:\n"));
+            target.push_str("\n;; ANSWER SECTION:\n");
             for item in section {
                 let item = item.expect("we created this message, it should be valid");
                 write_record_item(target, &item);
@@ -1122,7 +1122,7 @@ impl Update {
             .expect("we created this message, it should be valid")
             .unwrap();
         if counts.nscount() > 0 {
-            target.push_str(&format!("\n;; AUTHORITY SECTION:\n"));
+            target.push_str("\n;; AUTHORITY SECTION:\n");
             for item in section {
                 let item = item.expect("we created this message, it should be valid");
                 write_record_item(target, &item);
@@ -1135,7 +1135,7 @@ impl Update {
             .expect("we created this message, it should be valid")
             .unwrap();
         if counts.arcount() > 1 || (opt.is_none() && counts.arcount() > 0) {
-            target.push_str(&format!("\n;; ADDITIONAL SECTION:\n"));
+            target.push_str("\n;; ADDITIONAL SECTION:\n");
             for item in section {
                 let item = item.expect("we created this message, it should be valid");
                 if item.rtype() != Rtype::OPT {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -739,7 +739,6 @@ enum UpdateAction {
         /// Each RDATA argument will be parsed as if it was read from a zone file.
         ///
         /// Examples:
-        ///   $ dnst update some.example.com add TLSA '0 0 1 dead beef ...'
         ///   $ dnst update some.example.com add TXT \
         ///       '"Spacious String" "Another string for the same TXT record"' \
         ///       '"This is another TXT RR"'

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -680,8 +680,11 @@ impl Update {
                     };
 
                     let rcode = resp.header().rcode();
-                    if rcode != Rcode::NOERROR {
-                        writeln!(env.stdout(), ";; UPDATE response was {rcode}");
+                    if rcode == Rcode::SERVFAIL || rcode == Rcode::NOTIMP {
+                        writeln!(env.stderr(), "Skipping {name} @ {socket}: {rcode}");
+                        continue;
+                    } else if rcode != Rcode::NOERROR {
+                        writeln!(env.stdout(), "UPDATE response was {rcode}");
                     }
                     return Ok(());
                 }
@@ -698,8 +701,11 @@ impl Update {
                 };
 
                 let rcode = resp.header().rcode();
-                if rcode != Rcode::NOERROR {
-                    writeln!(env.stdout(), ";; UPDATE response was {rcode}");
+                if rcode == Rcode::SERVFAIL || rcode == Rcode::NOTIMP {
+                    writeln!(env.stderr(), "Skipping _ @ {socket}: {rcode}");
+                    continue;
+                } else if rcode != Rcode::NOERROR {
+                    writeln!(env.stdout(), "UPDATE response was {rcode}");
                 }
                 return Ok(());
             }
@@ -707,7 +713,7 @@ impl Update {
 
         // Our list of nsnames has been exhausted, we can only report that
         // we couldn't find anything.
-        writeln!(env.stdout(), ";; No responses");
+        writeln!(env.stdout(), "No successful responses");
 
         Ok(())
     }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1006,6 +1006,7 @@ impl Update {
         target
     }
 
+    // Code from dnsi:src/output/dig.rs with io:Write replaced with push_str
     fn answer_to_dig_fmt(msg: &Message<bytes::Bytes>, target: &mut String, socket: SocketAddr) {
         fn write_record_item(target: &mut String, item: &domain::base::ParsedRecord<bytes::Bytes>) {
             let parsed = item.to_any_record::<AllRecordData<_, _>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use commands::keygen::Keygen;
 use commands::notify::Notify;
 use commands::nsec3hash::Nsec3Hash;
 use commands::signzone::SignZone;
-use commands::update::Update;
+use commands::update::{LdnsUpdate, Update};
 use commands::LdnsCommand;
 use domain::base::zonefile_fmt::DisplayKind;
 use env::Env;
@@ -49,7 +49,7 @@ pub fn try_ldns_compatibility<I: IntoIterator<Item = OsString>>(
         "keygen" => Keygen::parse_ldns_args(args_iter),
         "nsec3-hash" => Nsec3Hash::parse_ldns_args(args_iter),
         "signzone" => SignZone::parse_ldns_args(args_iter),
-        "update" => Update::parse_ldns_args(args_iter),
+        "update" => LdnsUpdate::parse_ldns_args(args_iter),
         _ => Err(format!("Unrecognized ldns command 'ldns-{binary_name}'").into()),
     }?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use commands::keygen::Keygen;
 use commands::notify::Notify;
 use commands::nsec3hash::Nsec3Hash;
 use commands::signzone::SignZone;
-use commands::update::{LdnsUpdate, Update};
+use commands::update::LdnsUpdate;
 use commands::LdnsCommand;
 use domain::base::zonefile_fmt::DisplayKind;
 use env::Env;


### PR DESCRIPTION
The new syntax:
- `dnst update [options] <domain name> add <RRTYPE> <RDATA>...`
- `dnst update [options] <domain name> delete <RRTYPE> [<RDATA>...]`
- `dnst update [options] <domain name> clear` (distinction to avoid accidental deletion of whole domain names)

Options:
```
  -c, --class <CLASS>
          Class [default: IN]
  -t, --ttl <TTL>
          TTL in seconds or with unit suffix (s, m, h, d, w, M, y) [default: 3600]
  -s, --server <IP>
          Name server to send the update to (can be provided multiple times)
  -z, --zone <ZONE>
          Zone the domain name belongs to (to skip SOA query)
  -y, --tsig <NAME:KEY[:ALGO]>
          TSIG credentials for the UPDATE packet
      --rrset-exists <DOMAIN_NAME_AND_TYPE>
          RRset exists (value independent). (Optionally) provide this option multiple times, with format "<DOMAIN_NAME> <TYPE>" each, to build up a list of RR(set)s [aliases: --rrset]
      --rrset-exists-exact <RESOURCE_RECORD>
          RRset exists (value dependent). (Optionally) provide this option multiple times, each with one RR in zonefile format, to build up one or more RRsets that is required to exist. CLASS and TTL can be omitted [aliases: --rrset-exact]
      --rrset-non-existent <DOMAIN_NAME_AND_TYPE>
          RRset does not exist. (Optionally) provide this option multiple times, with format "<DOMAIN_NAME> <TYPE>" each, to build up a list of RRs that specify that no RRs with a specified NAME and TYPE can exist [aliases: --rrset-empty]
      --name-in-use <DOMAIN_NAME>
          Name is in use. (Optionally) provide this option multiple times, with format "<DOMAIN_NAME>" each, to collect a list of NAMEs that must own at least one RR [aliases: --name-used]
      --name-not-in-use <DOMAIN_NAME>
          Name is not in use. (Optionally) provide this option multiple times, with format "<DOMAIN_NAME>" each, to collect a list of NAMEs that must NOT own any RRs [aliases: --name-unused]
```

Examples:
- `dnst update <domain name> add AAAA "::1" "::2"` - Add multiple AAAA records
- `dnst update <domain name> add TXT "challenge1" '"Second RR with space" "and 2 strings"'` - Add multiple TXT records
- `dnst update <domain name> delete AAAA ::1 ::2` - Delete exact AAAA RRs on domain name (`::1` and `::2` in this case)
- `dnst update <domain name> delete AAAA` - Delete all AAAA RRs on domain name
- `dnst update <domain name> clear` - Delete all RRSETs on domain name, aka delete the whole domain name

I thought about adding the domain name to the action to have it behind the action command, but put it to the update command instead to reduce code duplication. But on the other hand it's not much duplication... 
So, any preferences on `dnst update example.com add TXT Hallo` vs. `dnst update add example.com TXT Hallo`?

Left over TODOs:

- [x] Check if more errors could use some `.context()`
- [x] "pass SOA record fetched above to make sure changes to the SOA record by the user adhere to the RFC specifications of e.g. only increasing serial"
  - The RFC requires updates to the SOA RR to only increase the serial.
- [ ] Add `from_rtype_and_str` to domain's ZoneRecordData to skip the workaround with zonefile?
  - Currently, I'm parsing the rdata using `inplace::Zonefile` by creating a temporary RR and using only the resulting parsed rdata.
- [ ] Add tests triggering the runtime checks
- [ ] Add stelline tests
- [x] Document the format of RDATA arguments (e.g. what to do with a TXT record using multiple quoted strings)
- [x] Update the dnst update man page


Fixes: #42