### PR TITLE
Add tests for `dnst update`

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1885,4 +1885,6 @@ mod test {
         );
         assert_eq!(res.stderr, "");
     }
+
+    // TODO: add stelline tests for `dnst update`
 }


### PR DESCRIPTION
Draft PR to log the remaining TODOs and their progress:

Definitely:
- [ ] Add tests triggering the runtime checks
- [ ] Add stelline tests
- [ ] Simplify error mapping (remove `-> Error ... into()`) (see https://github.com/NLnetLabs/dnst/pull/115#discussion_r2318135214)

Maybe:
- [ ] Add from_rtype_and_str to domain's ZoneRecordData to skip the workaround with zonefile?
  - Currently, I'm parsing the rdata using inplace::Zonefile by creating a temporary RR and using only the resulting parsed rdata.