### PR TITLE
Respect color choices from env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "rayon",
  "regex",
  "ring",
+ "supports-color",
  "tempfile",
  "test_bin",
  "tokio",
@@ -567,6 +568,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1192,6 +1199,15 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ jiff = { version = "0.2", default-features = false, features = ["alloc", "std"] 
 _unused_lazy_static = { package = "lazy_static", version = "1.0.2" }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+supports-color = "3.0.2"
 
 [dev-dependencies]
 const_format = " 0.2.33"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use domain::base::wire::ParseError;
+use supports_color::Stream;
 use tracing::error;
 
 use crate::env::Env;
@@ -67,7 +68,11 @@ impl Error {
             // clap produces and return.
             PrimaryError::Clap(e) => {
                 let mut err = env.stderr();
-                writeln!(err, "{}", e.render().ansi());
+                if supports_color::on(Stream::Stderr).is_some_and(|s| s.has_basic) {
+                    writeln!(err, "{}", e.render().ansi())
+                } else {
+                    writeln!(err, "{}", e.render())
+                }
                 return;
             }
             PrimaryError::Other(error) => error,


### PR DESCRIPTION
We were printing the error message from clap ourselves, which meant that it wasn't respecting the color set from the environment variables.

Closes https://github.com/NLnetLabs/dnst/issues/134