### PR TITLE
keygen, keyset: use secure file permissions for key material

### DIFF
--- a/src/commands/keygen.rs
+++ b/src/commands/keygen.rs
@@ -683,7 +683,6 @@ mod test {
                 "Unsafe permissions on private key"
             );
         }
-
     }
 
     #[test]

--- a/src/commands/keygen.rs
+++ b/src/commands/keygen.rs
@@ -350,11 +350,11 @@ impl Keygen {
         let public_key_path = format!("{base}.key");
         let digest_file_path = self.make_ksk.then(|| format!("{base}.ds"));
 
-        let mut secret_key_file = util::create_new_file(&env, &secret_key_path)?;
-        let mut public_key_file = util::create_new_file(&env, &public_key_path)?;
+        let mut secret_key_file = util::create_new_file(&env, &secret_key_path, 0o600)?;
+        let mut public_key_file = util::create_new_file(&env, &public_key_path, 0o644)?;
         let mut digest_file = digest_file_path
             .as_ref()
-            .map(|digest_file_path| util::create_new_file(&env, digest_file_path))
+            .map(|digest_file_path| util::create_new_file(&env, digest_file_path, 0o644))
             .transpose()?;
 
         Self::symlink(&secret_key_path, ".private", self.symlink, &env)?;
@@ -431,6 +431,7 @@ impl Keygen {
 mod test {
     use domain::base::iana::SecurityAlgorithm;
     use regex::Regex;
+    use std::os::unix::fs::PermissionsExt;
 
     use crate::commands::Command;
     use crate::env::fake::FakeCmd;
@@ -667,6 +668,17 @@ mod test {
         let secret_key =
             std::fs::read_to_string(dir.path().join(format!("{name}.private"))).unwrap();
         assert!(secret_key_regex.is_match(&secret_key));
+
+        let permissions = std::fs::File::open(dir.path().join(format!("{name}.private")))
+            .unwrap()
+            .metadata()
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            permissions.mode() & 0o777,
+            0o600,
+            "Unsafe permissions on private key"
+        );
     }
 
     #[test]

--- a/src/commands/keygen.rs
+++ b/src/commands/keygen.rs
@@ -431,6 +431,7 @@ impl Keygen {
 mod test {
     use domain::base::iana::SecurityAlgorithm;
     use regex::Regex;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
     use crate::commands::Command;
@@ -669,16 +670,20 @@ mod test {
             std::fs::read_to_string(dir.path().join(format!("{name}.private"))).unwrap();
         assert!(secret_key_regex.is_match(&secret_key));
 
-        let permissions = std::fs::File::open(dir.path().join(format!("{name}.private")))
-            .unwrap()
-            .metadata()
-            .unwrap()
-            .permissions();
-        assert_eq!(
-            permissions.mode() & 0o777,
-            0o600,
-            "Unsafe permissions on private key"
-        );
+        #[cfg(unix)]
+        {
+            let permissions = std::fs::File::open(dir.path().join(format!("{name}.private")))
+                .unwrap()
+                .metadata()
+                .unwrap()
+                .permissions();
+            assert_eq!(
+                permissions.mode() & 0o777,
+                0o600,
+                "Unsafe permissions on private key"
+            );
+        }
+
     }
 
     #[test]

--- a/src/commands/keyset/cmd.rs
+++ b/src/commands/keyset/cmd.rs
@@ -60,6 +60,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::fs::{create_dir_all, remove_file, rename, File};
 use std::io::{self, Write};
 use std::net::{IpAddr, SocketAddr};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{absolute, Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
@@ -3034,8 +3035,8 @@ impl WorkSpace {
         let mut public_key_path = keys_dir.to_path_buf();
         public_key_path.push(Path::new(&format!("{base}.key")));
 
-        let mut secret_key_file = util::create_new_file(&env, &secret_key_path)?;
-        let mut public_key_file = util::create_new_file(&env, &public_key_path)?;
+        let mut secret_key_file = util::create_new_file(&env, &secret_key_path, 0o600)?;
+        let mut public_key_file = util::create_new_file(&env, &public_key_path, 0o644)?;
         // Prepare the contents to write.
         let secret_key = secret_key.display_as_bind().to_string();
         let public_key = display_as_bind(&public_key).to_string();
@@ -4272,7 +4273,12 @@ impl WorkSpace {
         //		ws.config.state_file.display()).into());
         // }
         filename_new.as_mut_os_string().push(".new");
-        let mut file = File::create(&filename_new)
+        let mut file = File::options()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o644)
+            .open(&filename_new)
             .map_err(|e| format!("unable to create file {}: {e}", filename_new.display()))?;
         write!(file, "{json}")
             .map_err(|e| format!("unable to write to file {}: {e}", filename_new.display()))?;

--- a/src/commands/keyset/cmd.rs
+++ b/src/commands/keyset/cmd.rs
@@ -60,6 +60,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::fs::{create_dir_all, remove_file, rename, File};
 use std::io::{self, Write};
 use std::net::{IpAddr, SocketAddr};
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{absolute, Path, PathBuf};
 use std::process::Command;
@@ -4273,11 +4274,11 @@ impl WorkSpace {
         //		ws.config.state_file.display()).into());
         // }
         filename_new.as_mut_os_string().push(".new");
-        let mut file = File::options()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o644)
+        let mut file_opts = File::options();
+        file_opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        file_opts.mode(0o644);
+        let mut file = file_opts
             .open(&filename_new)
             .map_err(|e| format!("unable to create file {}: {e}", filename_new.display()))?;
         write!(file, "{json}")

--- a/src/commands/keyset/kmip.rs
+++ b/src/commands/keyset/kmip.rs
@@ -553,7 +553,7 @@ pub fn kmip_command(
         }
 
         KmipCommands::ListServers => {
-            write!(env.stdout(), "{}", &kss.kmip);
+            write!(env.stdout(), "{}", kss.kmip);
             return Ok(false);
         }
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -32,7 +32,7 @@ where
         // Format values from the event's's metadata:
         let metadata = event.metadata();
 
-        write!(&mut writer, "[{}] ", &self.program)?;
+        write!(&mut writer, "[{}] ", self.program)?;
 
         let level = *metadata.level();
         if writer.has_ansi_escapes() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! A utility module for common operations.
 
 use std::fs::File;
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
@@ -8,14 +9,18 @@ use crate::env::Env;
 use crate::error::Result;
 
 /// Create and open a file.
-pub fn create_new_file(env: &impl Env, path: impl AsRef<Path>, mode: u32) -> Result<File> {
+pub fn create_new_file(
+    env: &impl Env,
+    path: impl AsRef<Path>,
+    #[cfg_attr(not(unix), allow(unused_variables))] mode: u32,
+) -> Result<File> {
     let path = path.as_ref();
     let abs_path = env.in_cwd(&path);
-    File::options()
-        .mode(mode)
-        .read(true)
-        .write(true)
-        .create_new(true)
+    let mut file_opts = File::options();
+    file_opts.read(true).write(true).create_new(true);
+    #[cfg(unix)]
+    file_opts.mode(mode);
+    file_opts
         .open(abs_path)
         .map_err(|err| format!("cannot create '{}': {err}", path.display()).into())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,16 +1,22 @@
 //! A utility module for common operations.
 
 use std::fs::File;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 use crate::env::Env;
 use crate::error::Result;
 
 /// Create and open a file.
-pub fn create_new_file(env: &impl Env, path: impl AsRef<Path>) -> Result<File> {
+pub fn create_new_file(env: &impl Env, path: impl AsRef<Path>, mode: u32) -> Result<File> {
     let path = path.as_ref();
     let abs_path = env.in_cwd(&path);
-    File::create_new(abs_path)
+    File::options()
+        .mode(mode)
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(abs_path)
         .map_err(|err| format!("cannot create '{}': {err}", path.display()).into())
 }
 


### PR DESCRIPTION
(private: u=rw,go= and public: u=rw,og=r)

Reported-by: Stéphane Bortzmeyer
Fixes: https://github.com/NLnetLabs/cascade/issues/238