### PR TITLE
Fix failing `dnst-ldnsutils` package testing failure.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -40,6 +40,16 @@ jobs:
       package_test_rules: pkg/dnst-ldnsutils/pkg/rules/packages-to-test.yml
       package_test_scripts_path: pkg/dnst-ldnsutils/pkg/test-scripts/test-<package>.sh
 
+      # Make sure that testing of the meta package dnst-ldnsutils is able
+      # to find a dnst package from the proposed repos to install.
+      deb_apt_source: 'deb [arch=amd64] https://packages.nlnetlabs.nl/linux/${OS_NAME}/ ${OS_REL}-proposed main'
+      rpm_yum_repo: |
+          [nlnetlabs]
+          name=NLnet Labs Testing
+          baseurl=https://packages.nlnetlabs.nl/linux/centos/$releasever/proposed/$basearch
+          enabled=1
+      package_test_always_add_repo: true
+
       rpm_scriptlets_path: pkg/dnst-ldnsutils/pkg/rpm/scriptlets.toml
 
       manifest_dir: pkg/dnst-ldnsutils


### PR DESCRIPTION
This PR fixes the currently failing (e.g. see [here](https://github.com/NLnetLabs/dnst/actions/runs/26761867007/job/78878041270#step:18:33)) fresh-install test of `dnst-ldnsutils`. It fails because it tries to install a `dnst` dependency package but doesn't have the necessary configuration for the `proposed` repository to which we have published prior versions of `dnst`.

Strictly speaking this should probably be trying to install the just built `dnst` as the dependency, but that's trickier to adapt the tests to do and the test is trying to show that the `Depends` metadata in the built `dnst-ldnsutils` package is correct, it doesn't matter which exact version of `dnst` it actually pulls in, it should just be the latest available.